### PR TITLE
Add workflow for backend tests

### DIFF
--- a/.github/workflows/backend-tests.yml
+++ b/.github/workflows/backend-tests.yml
@@ -1,0 +1,26 @@
+name: Backend Tests
+
+on:
+  push:
+    paths:
+      - 'backend/**'
+  pull_request:
+    paths:
+      - 'backend/**'
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: backend
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up JDK
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '17'
+          cache: maven
+      - name: Run tests
+        run: ./mvnw -B test


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to run backend Maven tests with JDK 17

## Testing
- `./mvnw -q test` *(fails: Failed to fetch https://repo.maven.apache.org/... apache-maven-3.9.11-bin.zip)*

------
https://chatgpt.com/codex/tasks/task_e_688f38b71fcc8320b3bbdfe35c3f1758