### PR TITLE
Add hello world endpoint and test

### DIFF
--- a/backend/src/main/java/org/example/backend/HelloController.java
+++ b/backend/src/main/java/org/example/backend/HelloController.java
@@ -1,0 +1,14 @@
+package org.example.backend;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class HelloController {
+
+    @GetMapping("/hello")
+    public String hello() {
+        return "Hello, World!";
+    }
+}
+

--- a/backend/src/test/java/org/example/backend/HelloControllerTest.java
+++ b/backend/src/test/java/org/example/backend/HelloControllerTest.java
@@ -1,0 +1,27 @@
+package org.example.backend;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class HelloControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Test
+    void helloEndpointReturnsHelloWorld() throws Exception {
+        mockMvc.perform(get("/hello"))
+                .andExpect(status().isOk())
+                .andExpect(content().string("Hello, World!"));
+    }
+}
+


### PR DESCRIPTION
## Summary
- add HelloController exposing `/hello` endpoint returning a friendly greeting
- add MockMvc test verifying the endpoint returns `Hello, World!`

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_688f3b57881c8320b124baf3d9dad2c8