### PR TITLE
Add user management endpoints

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -34,10 +34,15 @@
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-data-jpa</artifactId>
 		</dependency>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-web</artifactId>
-		</dependency>
+                <dependency>
+                        <groupId>org.springframework.boot</groupId>
+                        <artifactId>spring-boot-starter-web</artifactId>
+                </dependency>
+
+                <dependency>
+                        <groupId>org.springframework.boot</groupId>
+                        <artifactId>spring-boot-starter-validation</artifactId>
+                </dependency>
 
 		<dependency>
 			<groupId>org.springframework.boot</groupId>

--- a/backend/src/main/java/org/example/backend/user/controller/UserController.java
+++ b/backend/src/main/java/org/example/backend/user/controller/UserController.java
@@ -1,0 +1,37 @@
+package org.example.backend.user.controller;
+
+import org.example.backend.user.domain.User;
+import org.example.backend.user.dto.CreateUserRequest;
+import org.example.backend.user.service.UserService;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.server.ResponseStatusException;
+
+import jakarta.validation.Valid;
+
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/users")
+public class UserController {
+    private final UserService userService;
+
+    public UserController(UserService userService) {
+        this.userService = userService;
+    }
+
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    public User createUser(@Valid @RequestBody CreateUserRequest request) {
+        try {
+            return userService.createUser(request);
+        } catch (IllegalArgumentException e) {
+            throw new ResponseStatusException(HttpStatus.CONFLICT, e.getMessage(), e);
+        }
+    }
+
+    @DeleteMapping("/{id}")
+    public User deleteUser(@PathVariable String id) {
+        return userService.deleteUser(UUID.fromString(id));
+    }
+}

--- a/backend/src/main/java/org/example/backend/user/domain/User.java
+++ b/backend/src/main/java/org/example/backend/user/domain/User.java
@@ -1,0 +1,4 @@
+package org.example.backend.user.domain;
+
+public record User(String id, String email) {
+}

--- a/backend/src/main/java/org/example/backend/user/dto/CreateUserRequest.java
+++ b/backend/src/main/java/org/example/backend/user/dto/CreateUserRequest.java
@@ -1,0 +1,9 @@
+package org.example.backend.user.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record CreateUserRequest(
+        @NotBlank String email,
+        @NotBlank String password
+) {
+}

--- a/backend/src/main/java/org/example/backend/user/entity/UserEntity.java
+++ b/backend/src/main/java/org/example/backend/user/entity/UserEntity.java
@@ -1,0 +1,78 @@
+package org.example.backend.user.entity;
+
+import jakarta.persistence.*;
+
+import java.time.Instant;
+import java.util.UUID;
+
+@Entity
+@Table(name = "users")
+public class UserEntity {
+    @Id
+    @GeneratedValue
+    private UUID id;
+
+    @Column(nullable = false, unique = true)
+    private String email;
+
+    @Column(name = "password_hash", nullable = false)
+    private String passwordHash;
+
+    @Column(name = "created_at", updatable = false)
+    private Instant createdAt;
+
+    @Column(name = "updated_at")
+    private Instant updatedAt;
+
+    @PrePersist
+    public void prePersist() {
+        Instant now = Instant.now();
+        this.createdAt = now;
+        this.updatedAt = now;
+    }
+
+    @PreUpdate
+    public void preUpdate() {
+        this.updatedAt = Instant.now();
+    }
+
+    public UUID getId() {
+        return id;
+    }
+
+    public void setId(UUID id) {
+        this.id = id;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public void setEmail(String email) {
+        this.email = email;
+    }
+
+    public String getPasswordHash() {
+        return passwordHash;
+    }
+
+    public void setPasswordHash(String passwordHash) {
+        this.passwordHash = passwordHash;
+    }
+
+    public Instant getCreatedAt() {
+        return createdAt;
+    }
+
+    public void setCreatedAt(Instant createdAt) {
+        this.createdAt = createdAt;
+    }
+
+    public Instant getUpdatedAt() {
+        return updatedAt;
+    }
+
+    public void setUpdatedAt(Instant updatedAt) {
+        this.updatedAt = updatedAt;
+    }
+}

--- a/backend/src/main/java/org/example/backend/user/repository/UserRepository.java
+++ b/backend/src/main/java/org/example/backend/user/repository/UserRepository.java
@@ -1,0 +1,10 @@
+package org.example.backend.user.repository;
+
+import org.example.backend.user.entity.UserEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.UUID;
+
+public interface UserRepository extends JpaRepository<UserEntity, UUID> {
+    boolean existsByEmail(String email);
+}

--- a/backend/src/main/java/org/example/backend/user/service/UserService.java
+++ b/backend/src/main/java/org/example/backend/user/service/UserService.java
@@ -1,0 +1,37 @@
+package org.example.backend.user.service;
+
+import org.example.backend.user.domain.User;
+import org.example.backend.user.dto.CreateUserRequest;
+import org.example.backend.user.entity.UserEntity;
+import org.example.backend.user.repository.UserRepository;
+import org.springframework.stereotype.Service;
+
+import java.util.UUID;
+
+@Service
+public class UserService {
+    private final UserRepository userRepository;
+
+    public UserService(UserRepository userRepository) {
+        this.userRepository = userRepository;
+    }
+
+    public User createUser(CreateUserRequest request) {
+        if (userRepository.existsByEmail(request.email())) {
+            throw new IllegalArgumentException("User already exists");
+        }
+
+        UserEntity entity = new UserEntity();
+        entity.setEmail(request.email());
+        entity.setPasswordHash(request.password());
+        UserEntity saved = userRepository.save(entity);
+        return new User(saved.getId().toString(), saved.getEmail());
+    }
+
+    public User deleteUser(UUID id) {
+        UserEntity entity = userRepository.findById(id)
+                .orElseThrow(() -> new IllegalArgumentException("User not found"));
+        userRepository.delete(entity);
+        return new User(entity.getId().toString(), entity.getEmail());
+    }
+}

--- a/backend/src/test/java/org/example/backend/user/UserIntegrationTest.java
+++ b/backend/src/test/java/org/example/backend/user/UserIntegrationTest.java
@@ -1,0 +1,53 @@
+package org.example.backend.user;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+class UserIntegrationTest {
+    @Autowired
+    private MockMvc mockMvc;
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Test
+    void createAndDeleteUser() throws Exception {
+        MvcResult result = mockMvc.perform(post("/users")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"email\":\"integration@example.com\",\"password\":\"pass\"}"))
+                .andExpect(status().isCreated())
+                .andReturn();
+
+        String id = objectMapper.readTree(result.getResponse().getContentAsString()).get("id").asText();
+
+        mockMvc.perform(delete("/users/" + id))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value(id));
+    }
+
+    @Test
+    void createUserDuplicateEmail() throws Exception {
+        String body = "{\"email\":\"dup@example.com\",\"password\":\"pass\"}";
+        mockMvc.perform(post("/users")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isCreated());
+
+        mockMvc.perform(post("/users")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isConflict());
+    }
+}

--- a/backend/src/test/java/org/example/backend/user/controller/UserControllerTest.java
+++ b/backend/src/test/java/org/example/backend/user/controller/UserControllerTest.java
@@ -1,0 +1,73 @@
+package org.example.backend.user.controller;
+
+import org.example.backend.user.domain.User;
+import org.example.backend.user.dto.CreateUserRequest;
+import org.example.backend.user.service.UserService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.UUID;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(UserController.class)
+@ActiveProfiles("test")
+class UserControllerTest {
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private UserService userService;
+
+    @Test
+    void createUser() throws Exception {
+        User user = new User("1", "email@example.com");
+        when(userService.createUser(any(CreateUserRequest.class))).thenReturn(user);
+
+        mockMvc.perform(post("/users")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"email\":\"email@example.com\",\"password\":\"pass\"}"))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.id").value("1"))
+                .andExpect(jsonPath("$.email").value("email@example.com"));
+    }
+
+    @Test
+    void createUserValidationError() throws Exception {
+        mockMvc.perform(post("/users")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"email\":\"\",\"password\":\"\"}"))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void createUserDuplicateEmail() throws Exception {
+        when(userService.createUser(any(CreateUserRequest.class)))
+                .thenThrow(new IllegalArgumentException("User already exists"));
+
+        mockMvc.perform(post("/users")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"email\":\"email@example.com\",\"password\":\"pass\"}"))
+                .andExpect(status().isConflict());
+    }
+
+    @Test
+    void deleteUser() throws Exception {
+        UUID id = UUID.randomUUID();
+        User user = new User(id.toString(), "email@example.com");
+        when(userService.deleteUser(eq(id))).thenReturn(user);
+
+        mockMvc.perform(delete("/users/" + id))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value(id.toString()));
+    }
+}

--- a/backend/src/test/java/org/example/backend/user/repository/UserRepositoryTest.java
+++ b/backend/src/test/java/org/example/backend/user/repository/UserRepositoryTest.java
@@ -1,0 +1,34 @@
+package org.example.backend.user.repository;
+
+import org.example.backend.user.entity.UserEntity;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@DataJpaTest
+@ActiveProfiles("test")
+class UserRepositoryTest {
+    @Autowired
+    private UserRepository userRepository;
+
+    @Test
+    void saveAndDeleteUser() {
+        UserEntity entity = new UserEntity();
+        entity.setEmail("test@example.com");
+        entity.setPasswordHash("secret");
+        UserEntity saved = userRepository.save(entity);
+
+        Optional<UserEntity> found = userRepository.findById(saved.getId());
+        assertTrue(found.isPresent());
+        assertTrue(userRepository.existsByEmail("test@example.com"));
+
+        userRepository.deleteById(saved.getId());
+        assertFalse(userRepository.findById(saved.getId()).isPresent());
+        assertFalse(userRepository.existsByEmail("test@example.com"));
+    }
+}

--- a/backend/src/test/java/org/example/backend/user/service/UserServiceTest.java
+++ b/backend/src/test/java/org/example/backend/user/service/UserServiceTest.java
@@ -1,0 +1,66 @@
+package org.example.backend.user.service;
+
+import org.example.backend.user.domain.User;
+import org.example.backend.user.dto.CreateUserRequest;
+import org.example.backend.user.entity.UserEntity;
+import org.example.backend.user.repository.UserRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class UserServiceTest {
+    @Mock
+    private UserRepository userRepository;
+    @InjectMocks
+    private UserService userService;
+
+    @Test
+    void createUser() {
+        CreateUserRequest request = new CreateUserRequest("email@example.com", "pass");
+        UserEntity saved = new UserEntity();
+        saved.setId(UUID.randomUUID());
+        saved.setEmail("email@example.com");
+        saved.setPasswordHash("pass");
+
+        when(userRepository.save(any(UserEntity.class))).thenReturn(saved);
+
+        User result = userService.createUser(request);
+
+        assertEquals(saved.getId().toString(), result.id());
+        assertEquals("email@example.com", result.email());
+    }
+
+    @Test
+    void createUserDuplicateEmail() {
+        CreateUserRequest request = new CreateUserRequest("email@example.com", "pass");
+        when(userRepository.existsByEmail("email@example.com")).thenReturn(true);
+
+        assertThrows(IllegalArgumentException.class, () -> userService.createUser(request));
+    }
+
+    @Test
+    void deleteUser() {
+        UUID id = UUID.randomUUID();
+        UserEntity entity = new UserEntity();
+        entity.setId(id);
+        entity.setEmail("email@example.com");
+        entity.setPasswordHash("pass");
+
+        when(userRepository.findById(id)).thenReturn(Optional.of(entity));
+
+        User result = userService.deleteUser(id);
+
+        verify(userRepository).delete(entity);
+        assertEquals(id.toString(), result.id());
+    }
+}


### PR DESCRIPTION
## Summary
- add user entity, repository, service, controller and request DTO
- support creating and deleting users via REST API
- validate user creation input and block duplicate emails
- include unit and integration tests for new user endpoints

## Testing
- `./mvnw -q test` *(fails: wget Failed to fetch https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.11/apache-maven-3.9.11-bin.zip)*

------
https://chatgpt.com/codex/tasks/task_e_6891843677648320b0cf4aa7baecf5d8