### PR TITLE
Add user customer controller with CRUD operations

### DIFF
--- a/backend/src/main/java/org/example/backend/customer/controller/CustomerController.java
+++ b/backend/src/main/java/org/example/backend/customer/controller/CustomerController.java
@@ -1,0 +1,51 @@
+package org.example.backend.customer.controller;
+
+import org.example.backend.customer.domain.Customer;
+import org.example.backend.customer.dto.CreateCustomerRequest;
+import org.example.backend.customer.dto.UpdateCustomerRequest;
+import org.example.backend.customer.service.CustomerService;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.server.ResponseStatusException;
+
+import jakarta.validation.Valid;
+
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/user/{userId}/customer")
+public class CustomerController {
+    private final CustomerService customerService;
+
+    public CustomerController(CustomerService customerService) {
+        this.customerService = customerService;
+    }
+
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    public Customer createCustomer(@PathVariable String userId,
+                                   @Valid @RequestBody CreateCustomerRequest request) {
+        return customerService.createCustomer(UUID.fromString(userId), request);
+    }
+
+    @PutMapping("/{customerId}")
+    public Customer updateCustomer(@PathVariable String userId,
+                                   @PathVariable String customerId,
+                                   @Valid @RequestBody UpdateCustomerRequest request) {
+        try {
+            return customerService.updateCustomer(UUID.fromString(userId), UUID.fromString(customerId), request);
+        } catch (IllegalArgumentException e) {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, e.getMessage(), e);
+        }
+    }
+
+    @DeleteMapping("/{customerId}")
+    public Customer deleteCustomer(@PathVariable String userId,
+                                   @PathVariable String customerId) {
+        try {
+            return customerService.deleteCustomer(UUID.fromString(userId), UUID.fromString(customerId));
+        } catch (IllegalArgumentException e) {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, e.getMessage(), e);
+        }
+    }
+}

--- a/backend/src/main/java/org/example/backend/customer/domain/Customer.java
+++ b/backend/src/main/java/org/example/backend/customer/domain/Customer.java
@@ -1,0 +1,4 @@
+package org.example.backend.customer.domain;
+
+public record Customer(String id, String name, String phone, String email, String address) {
+}

--- a/backend/src/main/java/org/example/backend/customer/dto/CreateCustomerRequest.java
+++ b/backend/src/main/java/org/example/backend/customer/dto/CreateCustomerRequest.java
@@ -1,0 +1,11 @@
+package org.example.backend.customer.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record CreateCustomerRequest(
+        @NotBlank String name,
+        String phone,
+        String email,
+        String address
+) {
+}

--- a/backend/src/main/java/org/example/backend/customer/dto/UpdateCustomerRequest.java
+++ b/backend/src/main/java/org/example/backend/customer/dto/UpdateCustomerRequest.java
@@ -1,0 +1,11 @@
+package org.example.backend.customer.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record UpdateCustomerRequest(
+        @NotBlank String name,
+        String phone,
+        String email,
+        String address
+) {
+}

--- a/backend/src/main/java/org/example/backend/customer/entity/CustomerEntity.java
+++ b/backend/src/main/java/org/example/backend/customer/entity/CustomerEntity.java
@@ -1,0 +1,90 @@
+package org.example.backend.customer.entity;
+
+import jakarta.persistence.*;
+
+import java.time.Instant;
+import java.util.UUID;
+
+@Entity
+@Table(name = "customers")
+public class CustomerEntity {
+    @Id
+    @GeneratedValue
+    private UUID id;
+
+    @Column(name = "user_id", nullable = false)
+    private UUID userId;
+
+    @Column(nullable = false)
+    private String name;
+
+    private String phone;
+
+    private String email;
+
+    private String address;
+
+    @Column(name = "created_at", updatable = false)
+    private Instant createdAt;
+
+    @PrePersist
+    public void prePersist() {
+        this.createdAt = Instant.now();
+    }
+
+    public UUID getId() {
+        return id;
+    }
+
+    public void setId(UUID id) {
+        this.id = id;
+    }
+
+    public UUID getUserId() {
+        return userId;
+    }
+
+    public void setUserId(UUID userId) {
+        this.userId = userId;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getPhone() {
+        return phone;
+    }
+
+    public void setPhone(String phone) {
+        this.phone = phone;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public void setEmail(String email) {
+        this.email = email;
+    }
+
+    public String getAddress() {
+        return address;
+    }
+
+    public void setAddress(String address) {
+        this.address = address;
+    }
+
+    public Instant getCreatedAt() {
+        return createdAt;
+    }
+
+    public void setCreatedAt(Instant createdAt) {
+        this.createdAt = createdAt;
+    }
+}

--- a/backend/src/main/java/org/example/backend/customer/repository/CustomerRepository.java
+++ b/backend/src/main/java/org/example/backend/customer/repository/CustomerRepository.java
@@ -1,0 +1,11 @@
+package org.example.backend.customer.repository;
+
+import org.example.backend.customer.entity.CustomerEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+import java.util.UUID;
+
+public interface CustomerRepository extends JpaRepository<CustomerEntity, UUID> {
+    Optional<CustomerEntity> findByIdAndUserId(UUID id, UUID userId);
+}

--- a/backend/src/main/java/org/example/backend/customer/service/CustomerService.java
+++ b/backend/src/main/java/org/example/backend/customer/service/CustomerService.java
@@ -1,0 +1,58 @@
+package org.example.backend.customer.service;
+
+import org.example.backend.customer.domain.Customer;
+import org.example.backend.customer.dto.CreateCustomerRequest;
+import org.example.backend.customer.dto.UpdateCustomerRequest;
+import org.example.backend.customer.entity.CustomerEntity;
+import org.example.backend.customer.repository.CustomerRepository;
+import org.springframework.stereotype.Service;
+
+import java.util.UUID;
+
+@Service
+public class CustomerService {
+    private final CustomerRepository customerRepository;
+
+    public CustomerService(CustomerRepository customerRepository) {
+        this.customerRepository = customerRepository;
+    }
+
+    public Customer createCustomer(UUID userId, CreateCustomerRequest request) {
+        CustomerEntity entity = new CustomerEntity();
+        entity.setUserId(userId);
+        entity.setName(request.name());
+        entity.setPhone(request.phone());
+        entity.setEmail(request.email());
+        entity.setAddress(request.address());
+        CustomerEntity saved = customerRepository.save(entity);
+        return toDomain(saved);
+    }
+
+    public Customer updateCustomer(UUID userId, UUID customerId, UpdateCustomerRequest request) {
+        CustomerEntity entity = customerRepository.findByIdAndUserId(customerId, userId)
+                .orElseThrow(() -> new IllegalArgumentException("Customer not found"));
+        entity.setName(request.name());
+        entity.setPhone(request.phone());
+        entity.setEmail(request.email());
+        entity.setAddress(request.address());
+        CustomerEntity saved = customerRepository.save(entity);
+        return toDomain(saved);
+    }
+
+    public Customer deleteCustomer(UUID userId, UUID customerId) {
+        CustomerEntity entity = customerRepository.findByIdAndUserId(customerId, userId)
+                .orElseThrow(() -> new IllegalArgumentException("Customer not found"));
+        customerRepository.delete(entity);
+        return toDomain(entity);
+    }
+
+    private Customer toDomain(CustomerEntity entity) {
+        return new Customer(
+                entity.getId().toString(),
+                entity.getName(),
+                entity.getPhone(),
+                entity.getEmail(),
+                entity.getAddress()
+        );
+    }
+}

--- a/backend/src/test/java/org/example/backend/customer/CustomerIntegrationTest.java
+++ b/backend/src/test/java/org/example/backend/customer/CustomerIntegrationTest.java
@@ -1,0 +1,63 @@
+package org.example.backend.customer;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.example.backend.customer.dto.CreateCustomerRequest;
+import org.example.backend.customer.dto.UpdateCustomerRequest;
+import org.example.backend.user.entity.UserEntity;
+import org.example.backend.user.repository.UserRepository;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.UUID;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+class CustomerIntegrationTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Test
+    void createUpdateDeleteCustomerFlow() throws Exception {
+        UserEntity user = new UserEntity();
+        user.setEmail("test@example.com");
+        user.setPasswordHash("pw");
+        user = userRepository.save(user);
+        UUID userId = user.getId();
+
+        CreateCustomerRequest createRequest = new CreateCustomerRequest("John", "123", "john@example.com", "Street");
+        String createResponse = mockMvc.perform(post("/user/{userId}/customer", userId.toString())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(createRequest)))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.id").isNotEmpty())
+                .andReturn().getResponse().getContentAsString();
+        String customerId = objectMapper.readTree(createResponse).get("id").asText();
+
+        UpdateCustomerRequest updateRequest = new UpdateCustomerRequest("Jane", "456", "jane@example.com", "Road");
+        mockMvc.perform(put("/user/{userId}/customer/{customerId}", userId.toString(), customerId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(updateRequest)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.name").value("Jane"));
+
+        mockMvc.perform(delete("/user/{userId}/customer/{customerId}", userId.toString(), customerId))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value(customerId));
+    }
+}

--- a/backend/src/test/java/org/example/backend/customer/controller/CustomerControllerTest.java
+++ b/backend/src/test/java/org/example/backend/customer/controller/CustomerControllerTest.java
@@ -1,0 +1,73 @@
+package org.example.backend.customer.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.example.backend.customer.domain.Customer;
+import org.example.backend.customer.dto.CreateCustomerRequest;
+import org.example.backend.customer.dto.UpdateCustomerRequest;
+import org.example.backend.customer.service.CustomerService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.UUID;
+
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(CustomerController.class)
+class CustomerControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private CustomerService customerService;
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Test
+    void createCustomerReturnsCreatedCustomer() throws Exception {
+        UUID userId = UUID.randomUUID();
+        CreateCustomerRequest request = new CreateCustomerRequest("John", "123", "j@example.com", "Street");
+        Customer response = new Customer(UUID.randomUUID().toString(), "John", "123", "j@example.com", "Street");
+        given(customerService.createCustomer(eq(userId), any(CreateCustomerRequest.class))).willReturn(response);
+
+        mockMvc.perform(post("/user/{userId}/customer", userId.toString())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.name").value("John"));
+    }
+
+    @Test
+    void updateCustomerReturnsUpdatedCustomer() throws Exception {
+        UUID userId = UUID.randomUUID();
+        UUID customerId = UUID.randomUUID();
+        UpdateCustomerRequest request = new UpdateCustomerRequest("Jane", "456", "j2@example.com", "Road");
+        Customer response = new Customer(customerId.toString(), "Jane", "456", "j2@example.com", "Road");
+        given(customerService.updateCustomer(eq(userId), eq(customerId), any(UpdateCustomerRequest.class))).willReturn(response);
+
+        mockMvc.perform(put("/user/{userId}/customer/{customerId}", userId.toString(), customerId.toString())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.name").value("Jane"));
+    }
+
+    @Test
+    void deleteCustomerReturnsDeletedCustomer() throws Exception {
+        UUID userId = UUID.randomUUID();
+        UUID customerId = UUID.randomUUID();
+        Customer response = new Customer(customerId.toString(), "Del", "1", "e", "a");
+        given(customerService.deleteCustomer(userId, customerId)).willReturn(response);
+
+        mockMvc.perform(delete("/user/{userId}/customer/{customerId}", userId.toString(), customerId.toString()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value(customerId.toString()));
+    }
+}

--- a/backend/src/test/java/org/example/backend/customer/service/CustomerServiceTest.java
+++ b/backend/src/test/java/org/example/backend/customer/service/CustomerServiceTest.java
@@ -1,0 +1,83 @@
+package org.example.backend.customer.service;
+
+import org.example.backend.customer.domain.Customer;
+import org.example.backend.customer.dto.CreateCustomerRequest;
+import org.example.backend.customer.dto.UpdateCustomerRequest;
+import org.example.backend.customer.entity.CustomerEntity;
+import org.example.backend.customer.repository.CustomerRepository;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+class CustomerServiceTest {
+
+    private final CustomerRepository customerRepository = mock(CustomerRepository.class);
+    private final CustomerService customerService = new CustomerService(customerRepository);
+
+    @Test
+    void createCustomerSavesAndReturnsDomain() {
+        UUID userId = UUID.randomUUID();
+        CreateCustomerRequest request = new CreateCustomerRequest("John", "123", "j@example.com", "Street");
+
+        CustomerEntity savedEntity = new CustomerEntity();
+        savedEntity.setId(UUID.randomUUID());
+        savedEntity.setUserId(userId);
+        savedEntity.setName("John");
+        savedEntity.setPhone("123");
+        savedEntity.setEmail("j@example.com");
+        savedEntity.setAddress("Street");
+
+        when(customerRepository.save(any(CustomerEntity.class))).thenReturn(savedEntity);
+
+        Customer result = customerService.createCustomer(userId, request);
+
+        ArgumentCaptor<CustomerEntity> captor = ArgumentCaptor.forClass(CustomerEntity.class);
+        verify(customerRepository).save(captor.capture());
+        assertEquals("John", captor.getValue().getName());
+        assertEquals(savedEntity.getId().toString(), result.id());
+    }
+
+    @Test
+    void updateCustomerUpdatesFields() {
+        UUID userId = UUID.randomUUID();
+        UUID customerId = UUID.randomUUID();
+        UpdateCustomerRequest request = new UpdateCustomerRequest("Jane", "456", "j2@example.com", "Road");
+
+        CustomerEntity entity = new CustomerEntity();
+        entity.setId(customerId);
+        entity.setUserId(userId);
+        entity.setName("Old");
+
+        when(customerRepository.findByIdAndUserId(customerId, userId)).thenReturn(Optional.of(entity));
+        when(customerRepository.save(entity)).thenReturn(entity);
+
+        Customer result = customerService.updateCustomer(userId, customerId, request);
+
+        assertEquals("Jane", entity.getName());
+        verify(customerRepository).save(entity);
+        assertEquals(customerId.toString(), result.id());
+        assertEquals("Jane", result.name());
+    }
+
+    @Test
+    void deleteCustomerDeletesEntity() {
+        UUID userId = UUID.randomUUID();
+        UUID customerId = UUID.randomUUID();
+        CustomerEntity entity = new CustomerEntity();
+        entity.setId(customerId);
+        entity.setUserId(userId);
+        entity.setName("Del");
+
+        when(customerRepository.findByIdAndUserId(customerId, userId)).thenReturn(Optional.of(entity));
+
+        Customer result = customerService.deleteCustomer(userId, customerId);
+
+        verify(customerRepository).delete(entity);
+        assertEquals(customerId.toString(), result.id());
+    }
+}


### PR DESCRIPTION
## Summary
- add Customer domain, DTOs, JPA entity and repository
- implement /user/{userId}/customer controller with create, update, delete endpoints
- add service layer and unit/integration tests for customer flow

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM due to network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6891a9996fb883209953c4559b5dbf52