### PR TITLE
Add invoice endpoints with validation

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -59,6 +59,10 @@
 			<artifactId>h2</artifactId>
 			<scope>runtime</scope>
 		</dependency>
+		<dependency>
+			<groupId>com.fasterxml.jackson.datatype</groupId>
+			<artifactId>jackson-datatype-jsr310</artifactId>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/backend/src/main/java/org/example/backend/invoice/controller/InvoiceController.java
+++ b/backend/src/main/java/org/example/backend/invoice/controller/InvoiceController.java
@@ -1,0 +1,58 @@
+package org.example.backend.invoice.controller;
+
+import org.example.backend.invoice.domain.Invoice;
+import org.example.backend.invoice.dto.CreateInvoiceRequest;
+import org.example.backend.invoice.dto.UpdateInvoiceRequest;
+import org.example.backend.invoice.service.InvoiceService;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.server.ResponseStatusException;
+
+import jakarta.validation.Valid;
+
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/user/{userId}/customer/{customerId}/invoice")
+public class InvoiceController {
+    private final InvoiceService invoiceService;
+
+    public InvoiceController(InvoiceService invoiceService) {
+        this.invoiceService = invoiceService;
+    }
+
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    public Invoice createInvoice(@PathVariable String userId,
+                                 @PathVariable String customerId,
+                                 @Valid @RequestBody CreateInvoiceRequest request) {
+        try {
+            return invoiceService.createInvoice(UUID.fromString(userId), UUID.fromString(customerId), request);
+        } catch (IllegalArgumentException e) {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, e.getMessage(), e);
+        }
+    }
+
+    @PutMapping("/{invoiceId}")
+    public Invoice updateInvoice(@PathVariable String userId,
+                                 @PathVariable String customerId,
+                                 @PathVariable String invoiceId,
+                                 @Valid @RequestBody UpdateInvoiceRequest request) {
+        try {
+            return invoiceService.updateInvoice(UUID.fromString(userId), UUID.fromString(customerId), UUID.fromString(invoiceId), request);
+        } catch (IllegalArgumentException e) {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, e.getMessage(), e);
+        }
+    }
+
+    @DeleteMapping("/{invoiceId}")
+    public Invoice deleteInvoice(@PathVariable String userId,
+                                 @PathVariable String customerId,
+                                 @PathVariable String invoiceId) {
+        try {
+            return invoiceService.deleteInvoice(UUID.fromString(userId), UUID.fromString(customerId), UUID.fromString(invoiceId));
+        } catch (IllegalArgumentException e) {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, e.getMessage(), e);
+        }
+    }
+}

--- a/backend/src/main/java/org/example/backend/invoice/domain/Invoice.java
+++ b/backend/src/main/java/org/example/backend/invoice/domain/Invoice.java
@@ -1,0 +1,17 @@
+package org.example.backend.invoice.domain;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+
+public record Invoice(
+        String id,
+        String invoiceNumber,
+        LocalDate issueDate,
+        LocalDate dueDate,
+        String status,
+        BigDecimal taxAmount,
+        BigDecimal subtotal,
+        BigDecimal total,
+        String notes
+) {
+}

--- a/backend/src/main/java/org/example/backend/invoice/dto/CreateInvoiceRequest.java
+++ b/backend/src/main/java/org/example/backend/invoice/dto/CreateInvoiceRequest.java
@@ -1,0 +1,19 @@
+package org.example.backend.invoice.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+
+public record CreateInvoiceRequest(
+        @NotBlank String invoiceNumber,
+        @NotNull LocalDate issueDate,
+        LocalDate dueDate,
+        @NotBlank String status,
+        BigDecimal taxAmount,
+        BigDecimal subtotal,
+        BigDecimal total,
+        String notes
+) {
+}

--- a/backend/src/main/java/org/example/backend/invoice/dto/UpdateInvoiceRequest.java
+++ b/backend/src/main/java/org/example/backend/invoice/dto/UpdateInvoiceRequest.java
@@ -1,0 +1,19 @@
+package org.example.backend.invoice.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+
+public record UpdateInvoiceRequest(
+        @NotBlank String invoiceNumber,
+        @NotNull LocalDate issueDate,
+        LocalDate dueDate,
+        @NotBlank String status,
+        BigDecimal taxAmount,
+        BigDecimal subtotal,
+        BigDecimal total,
+        String notes
+) {
+}

--- a/backend/src/main/java/org/example/backend/invoice/entity/InvoiceEntity.java
+++ b/backend/src/main/java/org/example/backend/invoice/entity/InvoiceEntity.java
@@ -1,0 +1,147 @@
+package org.example.backend.invoice.entity;
+
+import jakarta.persistence.*;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.util.UUID;
+
+@Entity
+@Table(name = "invoices")
+public class InvoiceEntity {
+    @Id
+    @GeneratedValue
+    private UUID id;
+
+    @Column(name = "user_id", nullable = false)
+    private UUID userId;
+
+    @Column(name = "customer_id", nullable = false)
+    private UUID customerId;
+
+    @Column(name = "invoice_number", unique = true, nullable = false)
+    private String invoiceNumber;
+
+    @Column(name = "issue_date", nullable = false)
+    private LocalDate issueDate;
+
+    @Column(name = "due_date")
+    private LocalDate dueDate;
+
+    @Column(nullable = false)
+    private String status;
+
+    @Column(name = "tax_amount")
+    private BigDecimal taxAmount;
+
+    private BigDecimal subtotal;
+
+    private BigDecimal total;
+
+    private String notes;
+
+    @Column(name = "created_at", updatable = false)
+    private Instant createdAt;
+
+    @PrePersist
+    public void prePersist() {
+        this.createdAt = Instant.now();
+    }
+
+    public UUID getId() {
+        return id;
+    }
+
+    public void setId(UUID id) {
+        this.id = id;
+    }
+
+    public UUID getUserId() {
+        return userId;
+    }
+
+    public void setUserId(UUID userId) {
+        this.userId = userId;
+    }
+
+    public UUID getCustomerId() {
+        return customerId;
+    }
+
+    public void setCustomerId(UUID customerId) {
+        this.customerId = customerId;
+    }
+
+    public String getInvoiceNumber() {
+        return invoiceNumber;
+    }
+
+    public void setInvoiceNumber(String invoiceNumber) {
+        this.invoiceNumber = invoiceNumber;
+    }
+
+    public LocalDate getIssueDate() {
+        return issueDate;
+    }
+
+    public void setIssueDate(LocalDate issueDate) {
+        this.issueDate = issueDate;
+    }
+
+    public LocalDate getDueDate() {
+        return dueDate;
+    }
+
+    public void setDueDate(LocalDate dueDate) {
+        this.dueDate = dueDate;
+    }
+
+    public String getStatus() {
+        return status;
+    }
+
+    public void setStatus(String status) {
+        this.status = status;
+    }
+
+    public BigDecimal getTaxAmount() {
+        return taxAmount;
+    }
+
+    public void setTaxAmount(BigDecimal taxAmount) {
+        this.taxAmount = taxAmount;
+    }
+
+    public BigDecimal getSubtotal() {
+        return subtotal;
+    }
+
+    public void setSubtotal(BigDecimal subtotal) {
+        this.subtotal = subtotal;
+    }
+
+    public BigDecimal getTotal() {
+        return total;
+    }
+
+    public void setTotal(BigDecimal total) {
+        this.total = total;
+    }
+
+    public String getNotes() {
+        return notes;
+    }
+
+    public void setNotes(String notes) {
+        this.notes = notes;
+    }
+
+    public Instant getCreatedAt() {
+        return createdAt;
+    }
+
+    public void setCreatedAt(Instant createdAt) {
+        this.createdAt = createdAt;
+    }
+}

--- a/backend/src/main/java/org/example/backend/invoice/repository/InvoiceRepository.java
+++ b/backend/src/main/java/org/example/backend/invoice/repository/InvoiceRepository.java
@@ -1,0 +1,11 @@
+package org.example.backend.invoice.repository;
+
+import org.example.backend.invoice.entity.InvoiceEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+import java.util.UUID;
+
+public interface InvoiceRepository extends JpaRepository<InvoiceEntity, UUID> {
+    Optional<InvoiceEntity> findByIdAndUserIdAndCustomerId(UUID id, UUID userId, UUID customerId);
+}

--- a/backend/src/main/java/org/example/backend/invoice/service/InvoiceService.java
+++ b/backend/src/main/java/org/example/backend/invoice/service/InvoiceService.java
@@ -1,0 +1,85 @@
+package org.example.backend.invoice.service;
+
+import org.example.backend.customer.repository.CustomerRepository;
+import org.example.backend.invoice.domain.Invoice;
+import org.example.backend.invoice.dto.CreateInvoiceRequest;
+import org.example.backend.invoice.dto.UpdateInvoiceRequest;
+import org.example.backend.invoice.entity.InvoiceEntity;
+import org.example.backend.invoice.repository.InvoiceRepository;
+import org.example.backend.user.repository.UserRepository;
+import org.springframework.stereotype.Service;
+
+import java.util.UUID;
+
+@Service
+public class InvoiceService {
+    private final InvoiceRepository invoiceRepository;
+    private final UserRepository userRepository;
+    private final CustomerRepository customerRepository;
+
+    public InvoiceService(InvoiceRepository invoiceRepository,
+                          UserRepository userRepository,
+                          CustomerRepository customerRepository) {
+        this.invoiceRepository = invoiceRepository;
+        this.userRepository = userRepository;
+        this.customerRepository = customerRepository;
+    }
+
+    public Invoice createInvoice(UUID userId, UUID customerId, CreateInvoiceRequest request) {
+        if (!userRepository.existsById(userId)) {
+            throw new IllegalArgumentException("User not found");
+        }
+        customerRepository.findByIdAndUserId(customerId, userId)
+                .orElseThrow(() -> new IllegalArgumentException("Customer not found"));
+
+        InvoiceEntity entity = new InvoiceEntity();
+        entity.setUserId(userId);
+        entity.setCustomerId(customerId);
+        entity.setInvoiceNumber(request.invoiceNumber());
+        entity.setIssueDate(request.issueDate());
+        entity.setDueDate(request.dueDate());
+        entity.setStatus(request.status());
+        entity.setTaxAmount(request.taxAmount());
+        entity.setSubtotal(request.subtotal());
+        entity.setTotal(request.total());
+        entity.setNotes(request.notes());
+        InvoiceEntity saved = invoiceRepository.save(entity);
+        return toDomain(saved);
+    }
+
+    public Invoice updateInvoice(UUID userId, UUID customerId, UUID invoiceId, UpdateInvoiceRequest request) {
+        InvoiceEntity entity = invoiceRepository.findByIdAndUserIdAndCustomerId(invoiceId, userId, customerId)
+                .orElseThrow(() -> new IllegalArgumentException("Invoice not found"));
+        entity.setInvoiceNumber(request.invoiceNumber());
+        entity.setIssueDate(request.issueDate());
+        entity.setDueDate(request.dueDate());
+        entity.setStatus(request.status());
+        entity.setTaxAmount(request.taxAmount());
+        entity.setSubtotal(request.subtotal());
+        entity.setTotal(request.total());
+        entity.setNotes(request.notes());
+        InvoiceEntity saved = invoiceRepository.save(entity);
+        return toDomain(saved);
+    }
+
+    public Invoice deleteInvoice(UUID userId, UUID customerId, UUID invoiceId) {
+        InvoiceEntity entity = invoiceRepository.findByIdAndUserIdAndCustomerId(invoiceId, userId, customerId)
+                .orElseThrow(() -> new IllegalArgumentException("Invoice not found"));
+        invoiceRepository.delete(entity);
+        return toDomain(entity);
+    }
+
+    private Invoice toDomain(InvoiceEntity entity) {
+        return new Invoice(
+                entity.getId().toString(),
+                entity.getInvoiceNumber(),
+                entity.getIssueDate(),
+                entity.getDueDate(),
+                entity.getStatus(),
+                entity.getTaxAmount(),
+                entity.getSubtotal(),
+                entity.getTotal(),
+                entity.getNotes()
+        );
+    }
+}

--- a/backend/src/test/java/org/example/backend/customer/controller/CustomerControllerTest.java
+++ b/backend/src/test/java/org/example/backend/customer/controller/CustomerControllerTest.java
@@ -28,7 +28,7 @@ class CustomerControllerTest {
     @MockBean
     private CustomerService customerService;
 
-    private final ObjectMapper objectMapper = new ObjectMapper();
+    private final ObjectMapper objectMapper = new ObjectMapper().findAndRegisterModules();
 
     @Test
     void createCustomerReturnsCreatedCustomer() throws Exception {

--- a/backend/src/test/java/org/example/backend/invoice/InvoiceIntegrationTest.java
+++ b/backend/src/test/java/org/example/backend/invoice/InvoiceIntegrationTest.java
@@ -1,0 +1,76 @@
+package org.example.backend.invoice;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.example.backend.customer.entity.CustomerEntity;
+import org.example.backend.customer.repository.CustomerRepository;
+import org.example.backend.invoice.dto.CreateInvoiceRequest;
+import org.example.backend.invoice.dto.UpdateInvoiceRequest;
+import org.example.backend.user.entity.UserEntity;
+import org.example.backend.user.repository.UserRepository;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.UUID;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+class InvoiceIntegrationTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private CustomerRepository customerRepository;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Test
+    void createUpdateDeleteInvoiceFlow() throws Exception {
+        UserEntity user = new UserEntity();
+        user.setEmail("test@example.com");
+        user.setPasswordHash("pw");
+        user = userRepository.save(user);
+        UUID userId = user.getId();
+
+        CustomerEntity customer = new CustomerEntity();
+        customer.setUserId(userId);
+        customer.setName("Cust");
+        customer = customerRepository.save(customer);
+        UUID customerId = customer.getId();
+
+        CreateInvoiceRequest createRequest = new CreateInvoiceRequest("INV-1", LocalDate.now(), null, "unpaid", BigDecimal.ONE, BigDecimal.TEN, BigDecimal.valueOf(11), "note");
+        String createResponse = mockMvc.perform(post("/user/{userId}/customer/{customerId}/invoice", userId.toString(), customerId.toString())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(createRequest)))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.id").isNotEmpty())
+                .andReturn().getResponse().getContentAsString();
+        String invoiceId = objectMapper.readTree(createResponse).get("id").asText();
+
+        UpdateInvoiceRequest updateRequest = new UpdateInvoiceRequest("INV-2", LocalDate.now(), null, "paid", BigDecimal.ONE, BigDecimal.TEN, BigDecimal.valueOf(11), "note");
+        mockMvc.perform(put("/user/{userId}/customer/{customerId}/invoice/{invoiceId}", userId.toString(), customerId.toString(), invoiceId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(updateRequest)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.invoiceNumber").value("INV-2"));
+
+        mockMvc.perform(delete("/user/{userId}/customer/{customerId}/invoice/{invoiceId}", userId.toString(), customerId.toString(), invoiceId))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value(invoiceId));
+    }
+}

--- a/backend/src/test/java/org/example/backend/invoice/InvoiceIntegrationTest.java
+++ b/backend/src/test/java/org/example/backend/invoice/InvoiceIntegrationTest.java
@@ -42,7 +42,7 @@ class InvoiceIntegrationTest {
     @Test
     void createUpdateDeleteInvoiceFlow() throws Exception {
         UserEntity user = new UserEntity();
-        user.setEmail("test@example.com");
+        user.setEmail("test1@example.com");
         user.setPasswordHash("pw");
         user = userRepository.save(user);
         UUID userId = user.getId();

--- a/backend/src/test/java/org/example/backend/invoice/controller/InvoiceControllerTest.java
+++ b/backend/src/test/java/org/example/backend/invoice/controller/InvoiceControllerTest.java
@@ -30,7 +30,7 @@ class InvoiceControllerTest {
     @MockBean
     private InvoiceService invoiceService;
 
-    private final ObjectMapper objectMapper = new ObjectMapper();
+    private final ObjectMapper objectMapper = new ObjectMapper().findAndRegisterModules();
 
     @Test
     void createInvoiceReturnsCreatedInvoice() throws Exception {

--- a/backend/src/test/java/org/example/backend/invoice/controller/InvoiceControllerTest.java
+++ b/backend/src/test/java/org/example/backend/invoice/controller/InvoiceControllerTest.java
@@ -1,0 +1,78 @@
+package org.example.backend.invoice.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.example.backend.invoice.domain.Invoice;
+import org.example.backend.invoice.dto.CreateInvoiceRequest;
+import org.example.backend.invoice.dto.UpdateInvoiceRequest;
+import org.example.backend.invoice.service.InvoiceService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.UUID;
+
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(InvoiceController.class)
+class InvoiceControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private InvoiceService invoiceService;
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Test
+    void createInvoiceReturnsCreatedInvoice() throws Exception {
+        UUID userId = UUID.randomUUID();
+        UUID customerId = UUID.randomUUID();
+        CreateInvoiceRequest request = new CreateInvoiceRequest("INV-1", LocalDate.now(), null, "unpaid", BigDecimal.ONE, BigDecimal.TEN, BigDecimal.valueOf(11), "note");
+        Invoice response = new Invoice(UUID.randomUUID().toString(), "INV-1", LocalDate.now(), null, "unpaid", BigDecimal.ONE, BigDecimal.TEN, BigDecimal.valueOf(11), "note");
+        given(invoiceService.createInvoice(eq(userId), eq(customerId), any(CreateInvoiceRequest.class))).willReturn(response);
+
+        mockMvc.perform(post("/user/{userId}/customer/{customerId}/invoice", userId.toString(), customerId.toString())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.invoiceNumber").value("INV-1"));
+    }
+
+    @Test
+    void updateInvoiceReturnsUpdatedInvoice() throws Exception {
+        UUID userId = UUID.randomUUID();
+        UUID customerId = UUID.randomUUID();
+        UUID invoiceId = UUID.randomUUID();
+        UpdateInvoiceRequest request = new UpdateInvoiceRequest("INV-2", LocalDate.now(), null, "paid", BigDecimal.ONE, BigDecimal.TEN, BigDecimal.valueOf(11), "note");
+        Invoice response = new Invoice(invoiceId.toString(), "INV-2", LocalDate.now(), null, "paid", BigDecimal.ONE, BigDecimal.TEN, BigDecimal.valueOf(11), "note");
+        given(invoiceService.updateInvoice(eq(userId), eq(customerId), eq(invoiceId), any(UpdateInvoiceRequest.class))).willReturn(response);
+
+        mockMvc.perform(put("/user/{userId}/customer/{customerId}/invoice/{invoiceId}", userId.toString(), customerId.toString(), invoiceId.toString())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.invoiceNumber").value("INV-2"));
+    }
+
+    @Test
+    void deleteInvoiceReturnsDeletedInvoice() throws Exception {
+        UUID userId = UUID.randomUUID();
+        UUID customerId = UUID.randomUUID();
+        UUID invoiceId = UUID.randomUUID();
+        Invoice response = new Invoice(invoiceId.toString(), "INV-3", LocalDate.now(), null, "unpaid", BigDecimal.ONE, BigDecimal.TEN, BigDecimal.valueOf(11), "note");
+        given(invoiceService.deleteInvoice(userId, customerId, invoiceId)).willReturn(response);
+
+        mockMvc.perform(delete("/user/{userId}/customer/{customerId}/invoice/{invoiceId}", userId.toString(), customerId.toString(), invoiceId.toString()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value(invoiceId.toString()));
+    }
+}

--- a/backend/src/test/java/org/example/backend/invoice/service/InvoiceServiceTest.java
+++ b/backend/src/test/java/org/example/backend/invoice/service/InvoiceServiceTest.java
@@ -1,0 +1,120 @@
+package org.example.backend.invoice.service;
+
+import org.example.backend.customer.entity.CustomerEntity;
+import org.example.backend.customer.repository.CustomerRepository;
+import org.example.backend.invoice.domain.Invoice;
+import org.example.backend.invoice.dto.CreateInvoiceRequest;
+import org.example.backend.invoice.dto.UpdateInvoiceRequest;
+import org.example.backend.invoice.entity.InvoiceEntity;
+import org.example.backend.invoice.repository.InvoiceRepository;
+import org.example.backend.user.repository.UserRepository;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+class InvoiceServiceTest {
+
+    private final InvoiceRepository invoiceRepository = mock(InvoiceRepository.class);
+    private final UserRepository userRepository = mock(UserRepository.class);
+    private final CustomerRepository customerRepository = mock(CustomerRepository.class);
+    private final InvoiceService invoiceService = new InvoiceService(invoiceRepository, userRepository, customerRepository);
+
+    @Test
+    void createInvoiceSavesAndReturnsDomain() {
+        UUID userId = UUID.randomUUID();
+        UUID customerId = UUID.randomUUID();
+        CreateInvoiceRequest request = new CreateInvoiceRequest(
+                "INV-1",
+                LocalDate.now(),
+                LocalDate.now().plusDays(10),
+                "unpaid",
+                BigDecimal.ONE,
+                BigDecimal.TEN,
+                BigDecimal.valueOf(11),
+                "note"
+        );
+
+        when(userRepository.existsById(userId)).thenReturn(true);
+        when(customerRepository.findByIdAndUserId(customerId, userId)).thenReturn(Optional.of(new CustomerEntity()));
+
+        InvoiceEntity saved = new InvoiceEntity();
+        saved.setId(UUID.randomUUID());
+        saved.setUserId(userId);
+        saved.setCustomerId(customerId);
+        saved.setInvoiceNumber("INV-1");
+        saved.setIssueDate(request.issueDate());
+        saved.setDueDate(request.dueDate());
+        saved.setStatus(request.status());
+        saved.setTaxAmount(request.taxAmount());
+        saved.setSubtotal(request.subtotal());
+        saved.setTotal(request.total());
+        saved.setNotes(request.notes());
+
+        when(invoiceRepository.save(any(InvoiceEntity.class))).thenReturn(saved);
+
+        Invoice result = invoiceService.createInvoice(userId, customerId, request);
+
+        ArgumentCaptor<InvoiceEntity> captor = ArgumentCaptor.forClass(InvoiceEntity.class);
+        verify(invoiceRepository).save(captor.capture());
+        assertEquals("INV-1", captor.getValue().getInvoiceNumber());
+        assertEquals(saved.getId().toString(), result.id());
+    }
+
+    @Test
+    void updateInvoiceUpdatesFields() {
+        UUID userId = UUID.randomUUID();
+        UUID customerId = UUID.randomUUID();
+        UUID invoiceId = UUID.randomUUID();
+        UpdateInvoiceRequest request = new UpdateInvoiceRequest(
+                "INV-2",
+                LocalDate.now(),
+                LocalDate.now().plusDays(5),
+                "paid",
+                BigDecimal.ONE,
+                BigDecimal.TEN,
+                BigDecimal.valueOf(11),
+                "n2"
+        );
+
+        InvoiceEntity entity = new InvoiceEntity();
+        entity.setId(invoiceId);
+        entity.setUserId(userId);
+        entity.setCustomerId(customerId);
+        entity.setInvoiceNumber("OLD");
+
+        when(invoiceRepository.findByIdAndUserIdAndCustomerId(invoiceId, userId, customerId)).thenReturn(Optional.of(entity));
+        when(invoiceRepository.save(entity)).thenReturn(entity);
+
+        Invoice result = invoiceService.updateInvoice(userId, customerId, invoiceId, request);
+
+        assertEquals("INV-2", entity.getInvoiceNumber());
+        verify(invoiceRepository).save(entity);
+        assertEquals(invoiceId.toString(), result.id());
+    }
+
+    @Test
+    void deleteInvoiceDeletesEntity() {
+        UUID userId = UUID.randomUUID();
+        UUID customerId = UUID.randomUUID();
+        UUID invoiceId = UUID.randomUUID();
+        InvoiceEntity entity = new InvoiceEntity();
+        entity.setId(invoiceId);
+        entity.setUserId(userId);
+        entity.setCustomerId(customerId);
+        entity.setInvoiceNumber("INV");
+
+        when(invoiceRepository.findByIdAndUserIdAndCustomerId(invoiceId, userId, customerId)).thenReturn(Optional.of(entity));
+
+        Invoice result = invoiceService.deleteInvoice(userId, customerId, invoiceId);
+
+        verify(invoiceRepository).delete(entity);
+        assertEquals(invoiceId.toString(), result.id());
+    }
+}


### PR DESCRIPTION
## Summary
- add Invoice entity, repository, service, and controller following existing layering
- validate user and customer existence when creating invoices
- support create, update, and delete invoice operations and provide unit and integration tests

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6892895bed5483208aca243e654e602b