### PR TITLE
Add invoice item endpoint with validation and tests

### DIFF
--- a/backend/AGENTS.md
+++ b/backend/AGENTS.md
@@ -1,0 +1,27 @@
+# Backend Development Guidelines
+
+This file defines conventions for backend code.
+
+## Architecture
+
+- RESTful services must follow a controller-service-repository layering pattern.
+  - **Controller**: Handles HTTP requests and responses.
+  - **Service**: Encapsulates business logic.
+  - **Repository**: Manages data persistence.
+
+## Data Models
+
+- Define dedicated request DTO classes for each incoming API payload.
+- Services must convert request DTOs into entity models before repository interaction.
+- Service methods should return domain models representing business concepts.
+- Controllers must return these domain models in API responses.
+
+## Testing
+
+- Each layer requires unit tests to verify its behaviour.
+- Provide a Spring Boot integration test that exercises the full request pipeline.
+
+## API Responses
+
+- Convert `UUID` values to string when returning them in API responses.
+

--- a/backend/AGENTS.md
+++ b/backend/AGENTS.md
@@ -12,6 +12,7 @@ This file defines conventions for backend code.
 ## Data Models
 
 - Define dedicated request DTO classes for each incoming API payload.
+- Validate all incoming request DTOs to ensure they are neither empty nor null.
 - Services must convert request DTOs into entity models before repository interaction.
 - Service methods should return domain models representing business concepts.
 - Controllers must return these domain models in API responses.

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -59,6 +59,10 @@
 			<artifactId>h2</artifactId>
 			<scope>runtime</scope>
 		</dependency>
+		<dependency>
+			<groupId>com.fasterxml.jackson.datatype</groupId>
+			<artifactId>jackson-datatype-jsr310</artifactId>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -34,10 +34,15 @@
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-data-jpa</artifactId>
 		</dependency>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-web</artifactId>
-		</dependency>
+                <dependency>
+                        <groupId>org.springframework.boot</groupId>
+                        <artifactId>spring-boot-starter-web</artifactId>
+                </dependency>
+
+                <dependency>
+                        <groupId>org.springframework.boot</groupId>
+                        <artifactId>spring-boot-starter-validation</artifactId>
+                </dependency>
 
 		<dependency>
 			<groupId>org.springframework.boot</groupId>

--- a/backend/src/main/java/org/example/backend/customer/controller/CustomerController.java
+++ b/backend/src/main/java/org/example/backend/customer/controller/CustomerController.java
@@ -1,0 +1,51 @@
+package org.example.backend.customer.controller;
+
+import org.example.backend.customer.domain.Customer;
+import org.example.backend.customer.dto.CreateCustomerRequest;
+import org.example.backend.customer.dto.UpdateCustomerRequest;
+import org.example.backend.customer.service.CustomerService;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.server.ResponseStatusException;
+
+import jakarta.validation.Valid;
+
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/user/{userId}/customer")
+public class CustomerController {
+    private final CustomerService customerService;
+
+    public CustomerController(CustomerService customerService) {
+        this.customerService = customerService;
+    }
+
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    public Customer createCustomer(@PathVariable String userId,
+                                   @Valid @RequestBody CreateCustomerRequest request) {
+        return customerService.createCustomer(UUID.fromString(userId), request);
+    }
+
+    @PutMapping("/{customerId}")
+    public Customer updateCustomer(@PathVariable String userId,
+                                   @PathVariable String customerId,
+                                   @Valid @RequestBody UpdateCustomerRequest request) {
+        try {
+            return customerService.updateCustomer(UUID.fromString(userId), UUID.fromString(customerId), request);
+        } catch (IllegalArgumentException e) {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, e.getMessage(), e);
+        }
+    }
+
+    @DeleteMapping("/{customerId}")
+    public Customer deleteCustomer(@PathVariable String userId,
+                                   @PathVariable String customerId) {
+        try {
+            return customerService.deleteCustomer(UUID.fromString(userId), UUID.fromString(customerId));
+        } catch (IllegalArgumentException e) {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, e.getMessage(), e);
+        }
+    }
+}

--- a/backend/src/main/java/org/example/backend/customer/domain/Customer.java
+++ b/backend/src/main/java/org/example/backend/customer/domain/Customer.java
@@ -1,0 +1,4 @@
+package org.example.backend.customer.domain;
+
+public record Customer(String id, String name, String phone, String email, String address) {
+}

--- a/backend/src/main/java/org/example/backend/customer/dto/CreateCustomerRequest.java
+++ b/backend/src/main/java/org/example/backend/customer/dto/CreateCustomerRequest.java
@@ -1,0 +1,11 @@
+package org.example.backend.customer.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record CreateCustomerRequest(
+        @NotBlank String name,
+        String phone,
+        String email,
+        String address
+) {
+}

--- a/backend/src/main/java/org/example/backend/customer/dto/UpdateCustomerRequest.java
+++ b/backend/src/main/java/org/example/backend/customer/dto/UpdateCustomerRequest.java
@@ -1,0 +1,11 @@
+package org.example.backend.customer.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record UpdateCustomerRequest(
+        @NotBlank String name,
+        String phone,
+        String email,
+        String address
+) {
+}

--- a/backend/src/main/java/org/example/backend/customer/entity/CustomerEntity.java
+++ b/backend/src/main/java/org/example/backend/customer/entity/CustomerEntity.java
@@ -1,0 +1,90 @@
+package org.example.backend.customer.entity;
+
+import jakarta.persistence.*;
+
+import java.time.Instant;
+import java.util.UUID;
+
+@Entity
+@Table(name = "customers")
+public class CustomerEntity {
+    @Id
+    @GeneratedValue
+    private UUID id;
+
+    @Column(name = "user_id", nullable = false)
+    private UUID userId;
+
+    @Column(nullable = false)
+    private String name;
+
+    private String phone;
+
+    private String email;
+
+    private String address;
+
+    @Column(name = "created_at", updatable = false)
+    private Instant createdAt;
+
+    @PrePersist
+    public void prePersist() {
+        this.createdAt = Instant.now();
+    }
+
+    public UUID getId() {
+        return id;
+    }
+
+    public void setId(UUID id) {
+        this.id = id;
+    }
+
+    public UUID getUserId() {
+        return userId;
+    }
+
+    public void setUserId(UUID userId) {
+        this.userId = userId;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getPhone() {
+        return phone;
+    }
+
+    public void setPhone(String phone) {
+        this.phone = phone;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public void setEmail(String email) {
+        this.email = email;
+    }
+
+    public String getAddress() {
+        return address;
+    }
+
+    public void setAddress(String address) {
+        this.address = address;
+    }
+
+    public Instant getCreatedAt() {
+        return createdAt;
+    }
+
+    public void setCreatedAt(Instant createdAt) {
+        this.createdAt = createdAt;
+    }
+}

--- a/backend/src/main/java/org/example/backend/customer/repository/CustomerRepository.java
+++ b/backend/src/main/java/org/example/backend/customer/repository/CustomerRepository.java
@@ -1,0 +1,11 @@
+package org.example.backend.customer.repository;
+
+import org.example.backend.customer.entity.CustomerEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+import java.util.UUID;
+
+public interface CustomerRepository extends JpaRepository<CustomerEntity, UUID> {
+    Optional<CustomerEntity> findByIdAndUserId(UUID id, UUID userId);
+}

--- a/backend/src/main/java/org/example/backend/customer/service/CustomerService.java
+++ b/backend/src/main/java/org/example/backend/customer/service/CustomerService.java
@@ -1,0 +1,58 @@
+package org.example.backend.customer.service;
+
+import org.example.backend.customer.domain.Customer;
+import org.example.backend.customer.dto.CreateCustomerRequest;
+import org.example.backend.customer.dto.UpdateCustomerRequest;
+import org.example.backend.customer.entity.CustomerEntity;
+import org.example.backend.customer.repository.CustomerRepository;
+import org.springframework.stereotype.Service;
+
+import java.util.UUID;
+
+@Service
+public class CustomerService {
+    private final CustomerRepository customerRepository;
+
+    public CustomerService(CustomerRepository customerRepository) {
+        this.customerRepository = customerRepository;
+    }
+
+    public Customer createCustomer(UUID userId, CreateCustomerRequest request) {
+        CustomerEntity entity = new CustomerEntity();
+        entity.setUserId(userId);
+        entity.setName(request.name());
+        entity.setPhone(request.phone());
+        entity.setEmail(request.email());
+        entity.setAddress(request.address());
+        CustomerEntity saved = customerRepository.save(entity);
+        return toDomain(saved);
+    }
+
+    public Customer updateCustomer(UUID userId, UUID customerId, UpdateCustomerRequest request) {
+        CustomerEntity entity = customerRepository.findByIdAndUserId(customerId, userId)
+                .orElseThrow(() -> new IllegalArgumentException("Customer not found"));
+        entity.setName(request.name());
+        entity.setPhone(request.phone());
+        entity.setEmail(request.email());
+        entity.setAddress(request.address());
+        CustomerEntity saved = customerRepository.save(entity);
+        return toDomain(saved);
+    }
+
+    public Customer deleteCustomer(UUID userId, UUID customerId) {
+        CustomerEntity entity = customerRepository.findByIdAndUserId(customerId, userId)
+                .orElseThrow(() -> new IllegalArgumentException("Customer not found"));
+        customerRepository.delete(entity);
+        return toDomain(entity);
+    }
+
+    private Customer toDomain(CustomerEntity entity) {
+        return new Customer(
+                entity.getId().toString(),
+                entity.getName(),
+                entity.getPhone(),
+                entity.getEmail(),
+                entity.getAddress()
+        );
+    }
+}

--- a/backend/src/main/java/org/example/backend/invoice/controller/InvoiceController.java
+++ b/backend/src/main/java/org/example/backend/invoice/controller/InvoiceController.java
@@ -1,0 +1,58 @@
+package org.example.backend.invoice.controller;
+
+import org.example.backend.invoice.domain.Invoice;
+import org.example.backend.invoice.dto.CreateInvoiceRequest;
+import org.example.backend.invoice.dto.UpdateInvoiceRequest;
+import org.example.backend.invoice.service.InvoiceService;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.server.ResponseStatusException;
+
+import jakarta.validation.Valid;
+
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/user/{userId}/customer/{customerId}/invoice")
+public class InvoiceController {
+    private final InvoiceService invoiceService;
+
+    public InvoiceController(InvoiceService invoiceService) {
+        this.invoiceService = invoiceService;
+    }
+
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    public Invoice createInvoice(@PathVariable String userId,
+                                 @PathVariable String customerId,
+                                 @Valid @RequestBody CreateInvoiceRequest request) {
+        try {
+            return invoiceService.createInvoice(UUID.fromString(userId), UUID.fromString(customerId), request);
+        } catch (IllegalArgumentException e) {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, e.getMessage(), e);
+        }
+    }
+
+    @PutMapping("/{invoiceId}")
+    public Invoice updateInvoice(@PathVariable String userId,
+                                 @PathVariable String customerId,
+                                 @PathVariable String invoiceId,
+                                 @Valid @RequestBody UpdateInvoiceRequest request) {
+        try {
+            return invoiceService.updateInvoice(UUID.fromString(userId), UUID.fromString(customerId), UUID.fromString(invoiceId), request);
+        } catch (IllegalArgumentException e) {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, e.getMessage(), e);
+        }
+    }
+
+    @DeleteMapping("/{invoiceId}")
+    public Invoice deleteInvoice(@PathVariable String userId,
+                                 @PathVariable String customerId,
+                                 @PathVariable String invoiceId) {
+        try {
+            return invoiceService.deleteInvoice(UUID.fromString(userId), UUID.fromString(customerId), UUID.fromString(invoiceId));
+        } catch (IllegalArgumentException e) {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, e.getMessage(), e);
+        }
+    }
+}

--- a/backend/src/main/java/org/example/backend/invoice/domain/Invoice.java
+++ b/backend/src/main/java/org/example/backend/invoice/domain/Invoice.java
@@ -1,0 +1,17 @@
+package org.example.backend.invoice.domain;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+
+public record Invoice(
+        String id,
+        String invoiceNumber,
+        LocalDate issueDate,
+        LocalDate dueDate,
+        String status,
+        BigDecimal taxAmount,
+        BigDecimal subtotal,
+        BigDecimal total,
+        String notes
+) {
+}

--- a/backend/src/main/java/org/example/backend/invoice/dto/CreateInvoiceRequest.java
+++ b/backend/src/main/java/org/example/backend/invoice/dto/CreateInvoiceRequest.java
@@ -1,0 +1,19 @@
+package org.example.backend.invoice.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+
+public record CreateInvoiceRequest(
+        @NotBlank String invoiceNumber,
+        @NotNull LocalDate issueDate,
+        LocalDate dueDate,
+        @NotBlank String status,
+        BigDecimal taxAmount,
+        BigDecimal subtotal,
+        BigDecimal total,
+        String notes
+) {
+}

--- a/backend/src/main/java/org/example/backend/invoice/dto/UpdateInvoiceRequest.java
+++ b/backend/src/main/java/org/example/backend/invoice/dto/UpdateInvoiceRequest.java
@@ -1,0 +1,19 @@
+package org.example.backend.invoice.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+
+public record UpdateInvoiceRequest(
+        @NotBlank String invoiceNumber,
+        @NotNull LocalDate issueDate,
+        LocalDate dueDate,
+        @NotBlank String status,
+        BigDecimal taxAmount,
+        BigDecimal subtotal,
+        BigDecimal total,
+        String notes
+) {
+}

--- a/backend/src/main/java/org/example/backend/invoice/entity/InvoiceEntity.java
+++ b/backend/src/main/java/org/example/backend/invoice/entity/InvoiceEntity.java
@@ -1,0 +1,147 @@
+package org.example.backend.invoice.entity;
+
+import jakarta.persistence.*;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.util.UUID;
+
+@Entity
+@Table(name = "invoices")
+public class InvoiceEntity {
+    @Id
+    @GeneratedValue
+    private UUID id;
+
+    @Column(name = "user_id", nullable = false)
+    private UUID userId;
+
+    @Column(name = "customer_id", nullable = false)
+    private UUID customerId;
+
+    @Column(name = "invoice_number", unique = true, nullable = false)
+    private String invoiceNumber;
+
+    @Column(name = "issue_date", nullable = false)
+    private LocalDate issueDate;
+
+    @Column(name = "due_date")
+    private LocalDate dueDate;
+
+    @Column(nullable = false)
+    private String status;
+
+    @Column(name = "tax_amount")
+    private BigDecimal taxAmount;
+
+    private BigDecimal subtotal;
+
+    private BigDecimal total;
+
+    private String notes;
+
+    @Column(name = "created_at", updatable = false)
+    private Instant createdAt;
+
+    @PrePersist
+    public void prePersist() {
+        this.createdAt = Instant.now();
+    }
+
+    public UUID getId() {
+        return id;
+    }
+
+    public void setId(UUID id) {
+        this.id = id;
+    }
+
+    public UUID getUserId() {
+        return userId;
+    }
+
+    public void setUserId(UUID userId) {
+        this.userId = userId;
+    }
+
+    public UUID getCustomerId() {
+        return customerId;
+    }
+
+    public void setCustomerId(UUID customerId) {
+        this.customerId = customerId;
+    }
+
+    public String getInvoiceNumber() {
+        return invoiceNumber;
+    }
+
+    public void setInvoiceNumber(String invoiceNumber) {
+        this.invoiceNumber = invoiceNumber;
+    }
+
+    public LocalDate getIssueDate() {
+        return issueDate;
+    }
+
+    public void setIssueDate(LocalDate issueDate) {
+        this.issueDate = issueDate;
+    }
+
+    public LocalDate getDueDate() {
+        return dueDate;
+    }
+
+    public void setDueDate(LocalDate dueDate) {
+        this.dueDate = dueDate;
+    }
+
+    public String getStatus() {
+        return status;
+    }
+
+    public void setStatus(String status) {
+        this.status = status;
+    }
+
+    public BigDecimal getTaxAmount() {
+        return taxAmount;
+    }
+
+    public void setTaxAmount(BigDecimal taxAmount) {
+        this.taxAmount = taxAmount;
+    }
+
+    public BigDecimal getSubtotal() {
+        return subtotal;
+    }
+
+    public void setSubtotal(BigDecimal subtotal) {
+        this.subtotal = subtotal;
+    }
+
+    public BigDecimal getTotal() {
+        return total;
+    }
+
+    public void setTotal(BigDecimal total) {
+        this.total = total;
+    }
+
+    public String getNotes() {
+        return notes;
+    }
+
+    public void setNotes(String notes) {
+        this.notes = notes;
+    }
+
+    public Instant getCreatedAt() {
+        return createdAt;
+    }
+
+    public void setCreatedAt(Instant createdAt) {
+        this.createdAt = createdAt;
+    }
+}

--- a/backend/src/main/java/org/example/backend/invoice/repository/InvoiceRepository.java
+++ b/backend/src/main/java/org/example/backend/invoice/repository/InvoiceRepository.java
@@ -1,0 +1,11 @@
+package org.example.backend.invoice.repository;
+
+import org.example.backend.invoice.entity.InvoiceEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+import java.util.UUID;
+
+public interface InvoiceRepository extends JpaRepository<InvoiceEntity, UUID> {
+    Optional<InvoiceEntity> findByIdAndUserIdAndCustomerId(UUID id, UUID userId, UUID customerId);
+}

--- a/backend/src/main/java/org/example/backend/invoice/service/InvoiceService.java
+++ b/backend/src/main/java/org/example/backend/invoice/service/InvoiceService.java
@@ -1,0 +1,85 @@
+package org.example.backend.invoice.service;
+
+import org.example.backend.customer.repository.CustomerRepository;
+import org.example.backend.invoice.domain.Invoice;
+import org.example.backend.invoice.dto.CreateInvoiceRequest;
+import org.example.backend.invoice.dto.UpdateInvoiceRequest;
+import org.example.backend.invoice.entity.InvoiceEntity;
+import org.example.backend.invoice.repository.InvoiceRepository;
+import org.example.backend.user.repository.UserRepository;
+import org.springframework.stereotype.Service;
+
+import java.util.UUID;
+
+@Service
+public class InvoiceService {
+    private final InvoiceRepository invoiceRepository;
+    private final UserRepository userRepository;
+    private final CustomerRepository customerRepository;
+
+    public InvoiceService(InvoiceRepository invoiceRepository,
+                          UserRepository userRepository,
+                          CustomerRepository customerRepository) {
+        this.invoiceRepository = invoiceRepository;
+        this.userRepository = userRepository;
+        this.customerRepository = customerRepository;
+    }
+
+    public Invoice createInvoice(UUID userId, UUID customerId, CreateInvoiceRequest request) {
+        if (!userRepository.existsById(userId)) {
+            throw new IllegalArgumentException("User not found");
+        }
+        customerRepository.findByIdAndUserId(customerId, userId)
+                .orElseThrow(() -> new IllegalArgumentException("Customer not found"));
+
+        InvoiceEntity entity = new InvoiceEntity();
+        entity.setUserId(userId);
+        entity.setCustomerId(customerId);
+        entity.setInvoiceNumber(request.invoiceNumber());
+        entity.setIssueDate(request.issueDate());
+        entity.setDueDate(request.dueDate());
+        entity.setStatus(request.status());
+        entity.setTaxAmount(request.taxAmount());
+        entity.setSubtotal(request.subtotal());
+        entity.setTotal(request.total());
+        entity.setNotes(request.notes());
+        InvoiceEntity saved = invoiceRepository.save(entity);
+        return toDomain(saved);
+    }
+
+    public Invoice updateInvoice(UUID userId, UUID customerId, UUID invoiceId, UpdateInvoiceRequest request) {
+        InvoiceEntity entity = invoiceRepository.findByIdAndUserIdAndCustomerId(invoiceId, userId, customerId)
+                .orElseThrow(() -> new IllegalArgumentException("Invoice not found"));
+        entity.setInvoiceNumber(request.invoiceNumber());
+        entity.setIssueDate(request.issueDate());
+        entity.setDueDate(request.dueDate());
+        entity.setStatus(request.status());
+        entity.setTaxAmount(request.taxAmount());
+        entity.setSubtotal(request.subtotal());
+        entity.setTotal(request.total());
+        entity.setNotes(request.notes());
+        InvoiceEntity saved = invoiceRepository.save(entity);
+        return toDomain(saved);
+    }
+
+    public Invoice deleteInvoice(UUID userId, UUID customerId, UUID invoiceId) {
+        InvoiceEntity entity = invoiceRepository.findByIdAndUserIdAndCustomerId(invoiceId, userId, customerId)
+                .orElseThrow(() -> new IllegalArgumentException("Invoice not found"));
+        invoiceRepository.delete(entity);
+        return toDomain(entity);
+    }
+
+    private Invoice toDomain(InvoiceEntity entity) {
+        return new Invoice(
+                entity.getId().toString(),
+                entity.getInvoiceNumber(),
+                entity.getIssueDate(),
+                entity.getDueDate(),
+                entity.getStatus(),
+                entity.getTaxAmount(),
+                entity.getSubtotal(),
+                entity.getTotal(),
+                entity.getNotes()
+        );
+    }
+}

--- a/backend/src/main/java/org/example/backend/invoiceitem/controller/InvoiceItemController.java
+++ b/backend/src/main/java/org/example/backend/invoiceitem/controller/InvoiceItemController.java
@@ -1,0 +1,61 @@
+package org.example.backend.invoiceitem.controller;
+
+import org.example.backend.invoiceitem.domain.InvoiceItem;
+import org.example.backend.invoiceitem.dto.CreateInvoiceItemRequest;
+import org.example.backend.invoiceitem.dto.UpdateInvoiceItemRequest;
+import org.example.backend.invoiceitem.service.InvoiceItemService;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.server.ResponseStatusException;
+
+import jakarta.validation.Valid;
+
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/user/{userId}/customer/{customerId}/invoice/{invoiceId}/item")
+public class InvoiceItemController {
+    private final InvoiceItemService invoiceItemService;
+
+    public InvoiceItemController(InvoiceItemService invoiceItemService) {
+        this.invoiceItemService = invoiceItemService;
+    }
+
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    public InvoiceItem createItem(@PathVariable String userId,
+                                  @PathVariable String customerId,
+                                  @PathVariable String invoiceId,
+                                  @Valid @RequestBody CreateInvoiceItemRequest request) {
+        try {
+            return invoiceItemService.createItem(UUID.fromString(userId), UUID.fromString(customerId), UUID.fromString(invoiceId), request);
+        } catch (IllegalArgumentException e) {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, e.getMessage(), e);
+        }
+    }
+
+    @PutMapping("/{itemId}")
+    public InvoiceItem updateItem(@PathVariable String userId,
+                                  @PathVariable String customerId,
+                                  @PathVariable String invoiceId,
+                                  @PathVariable String itemId,
+                                  @Valid @RequestBody UpdateInvoiceItemRequest request) {
+        try {
+            return invoiceItemService.updateItem(UUID.fromString(userId), UUID.fromString(customerId), UUID.fromString(invoiceId), UUID.fromString(itemId), request);
+        } catch (IllegalArgumentException e) {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, e.getMessage(), e);
+        }
+    }
+
+    @DeleteMapping("/{itemId}")
+    public InvoiceItem deleteItem(@PathVariable String userId,
+                                  @PathVariable String customerId,
+                                  @PathVariable String invoiceId,
+                                  @PathVariable String itemId) {
+        try {
+            return invoiceItemService.deleteItem(UUID.fromString(userId), UUID.fromString(customerId), UUID.fromString(invoiceId), UUID.fromString(itemId));
+        } catch (IllegalArgumentException e) {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, e.getMessage(), e);
+        }
+    }
+}

--- a/backend/src/main/java/org/example/backend/invoiceitem/domain/InvoiceItem.java
+++ b/backend/src/main/java/org/example/backend/invoiceitem/domain/InvoiceItem.java
@@ -1,0 +1,12 @@
+package org.example.backend.invoiceitem.domain;
+
+import java.math.BigDecimal;
+
+public record InvoiceItem(
+        String id,
+        String description,
+        int quantity,
+        BigDecimal unitPrice,
+        BigDecimal totalPrice
+) {
+}

--- a/backend/src/main/java/org/example/backend/invoiceitem/dto/CreateInvoiceItemRequest.java
+++ b/backend/src/main/java/org/example/backend/invoiceitem/dto/CreateInvoiceItemRequest.java
@@ -1,0 +1,14 @@
+package org.example.backend.invoiceitem.dto;
+
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+import java.math.BigDecimal;
+
+public record CreateInvoiceItemRequest(
+        @NotBlank String description,
+        @Min(1) int quantity,
+        @NotNull BigDecimal unitPrice
+) {
+}

--- a/backend/src/main/java/org/example/backend/invoiceitem/dto/UpdateInvoiceItemRequest.java
+++ b/backend/src/main/java/org/example/backend/invoiceitem/dto/UpdateInvoiceItemRequest.java
@@ -1,0 +1,14 @@
+package org.example.backend.invoiceitem.dto;
+
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+import java.math.BigDecimal;
+
+public record UpdateInvoiceItemRequest(
+        @NotBlank String description,
+        @Min(1) int quantity,
+        @NotNull BigDecimal unitPrice
+) {
+}

--- a/backend/src/main/java/org/example/backend/invoiceitem/entity/InvoiceItemEntity.java
+++ b/backend/src/main/java/org/example/backend/invoiceitem/entity/InvoiceItemEntity.java
@@ -1,0 +1,77 @@
+package org.example.backend.invoiceitem.entity;
+
+import jakarta.persistence.*;
+
+import java.math.BigDecimal;
+import java.util.UUID;
+
+@Entity
+@Table(name = "invoice_items")
+public class InvoiceItemEntity {
+    @Id
+    @GeneratedValue
+    private UUID id;
+
+    @Column(name = "invoice_id", nullable = false)
+    private UUID invoiceId;
+
+    @Column(nullable = false)
+    private String description;
+
+    @Column(nullable = false)
+    private int quantity;
+
+    @Column(name = "unit_price", nullable = false)
+    private BigDecimal unitPrice;
+
+    @Column(name = "total_price")
+    private BigDecimal totalPrice;
+
+    public UUID getId() {
+        return id;
+    }
+
+    public void setId(UUID id) {
+        this.id = id;
+    }
+
+    public UUID getInvoiceId() {
+        return invoiceId;
+    }
+
+    public void setInvoiceId(UUID invoiceId) {
+        this.invoiceId = invoiceId;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    public int getQuantity() {
+        return quantity;
+    }
+
+    public void setQuantity(int quantity) {
+        this.quantity = quantity;
+    }
+
+    public BigDecimal getUnitPrice() {
+        return unitPrice;
+    }
+
+    public void setUnitPrice(BigDecimal unitPrice) {
+        this.unitPrice = unitPrice;
+    }
+
+    public BigDecimal getTotalPrice() {
+        return totalPrice;
+    }
+
+    public void setTotalPrice(BigDecimal totalPrice) {
+        this.totalPrice = totalPrice;
+    }
+}

--- a/backend/src/main/java/org/example/backend/invoiceitem/repository/InvoiceItemRepository.java
+++ b/backend/src/main/java/org/example/backend/invoiceitem/repository/InvoiceItemRepository.java
@@ -1,0 +1,11 @@
+package org.example.backend.invoiceitem.repository;
+
+import org.example.backend.invoiceitem.entity.InvoiceItemEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+import java.util.UUID;
+
+public interface InvoiceItemRepository extends JpaRepository<InvoiceItemEntity, UUID> {
+    Optional<InvoiceItemEntity> findByIdAndInvoiceId(UUID id, UUID invoiceId);
+}

--- a/backend/src/main/java/org/example/backend/invoiceitem/service/InvoiceItemService.java
+++ b/backend/src/main/java/org/example/backend/invoiceitem/service/InvoiceItemService.java
@@ -1,0 +1,72 @@
+package org.example.backend.invoiceitem.service;
+
+import org.example.backend.invoice.repository.InvoiceRepository;
+import org.example.backend.invoiceitem.domain.InvoiceItem;
+import org.example.backend.invoiceitem.dto.CreateInvoiceItemRequest;
+import org.example.backend.invoiceitem.dto.UpdateInvoiceItemRequest;
+import org.example.backend.invoiceitem.entity.InvoiceItemEntity;
+import org.example.backend.invoiceitem.repository.InvoiceItemRepository;
+import org.springframework.stereotype.Service;
+
+import java.math.BigDecimal;
+import java.util.UUID;
+
+@Service
+public class InvoiceItemService {
+    private final InvoiceItemRepository invoiceItemRepository;
+    private final InvoiceRepository invoiceRepository;
+
+    public InvoiceItemService(InvoiceItemRepository invoiceItemRepository,
+                              InvoiceRepository invoiceRepository) {
+        this.invoiceItemRepository = invoiceItemRepository;
+        this.invoiceRepository = invoiceRepository;
+    }
+
+    public InvoiceItem createItem(UUID userId, UUID customerId, UUID invoiceId, CreateInvoiceItemRequest request) {
+        invoiceRepository.findByIdAndUserIdAndCustomerId(invoiceId, userId, customerId)
+                .orElseThrow(() -> new IllegalArgumentException("Invoice not found"));
+
+        InvoiceItemEntity entity = new InvoiceItemEntity();
+        entity.setInvoiceId(invoiceId);
+        entity.setDescription(request.description());
+        entity.setQuantity(request.quantity());
+        entity.setUnitPrice(request.unitPrice());
+        entity.setTotalPrice(request.unitPrice().multiply(BigDecimal.valueOf(request.quantity())));
+        InvoiceItemEntity saved = invoiceItemRepository.save(entity);
+        return toDomain(saved);
+    }
+
+    public InvoiceItem updateItem(UUID userId, UUID customerId, UUID invoiceId, UUID itemId, UpdateInvoiceItemRequest request) {
+        invoiceRepository.findByIdAndUserIdAndCustomerId(invoiceId, userId, customerId)
+                .orElseThrow(() -> new IllegalArgumentException("Invoice not found"));
+
+        InvoiceItemEntity entity = invoiceItemRepository.findByIdAndInvoiceId(itemId, invoiceId)
+                .orElseThrow(() -> new IllegalArgumentException("Item not found"));
+        entity.setDescription(request.description());
+        entity.setQuantity(request.quantity());
+        entity.setUnitPrice(request.unitPrice());
+        entity.setTotalPrice(request.unitPrice().multiply(BigDecimal.valueOf(request.quantity())));
+        InvoiceItemEntity saved = invoiceItemRepository.save(entity);
+        return toDomain(saved);
+    }
+
+    public InvoiceItem deleteItem(UUID userId, UUID customerId, UUID invoiceId, UUID itemId) {
+        invoiceRepository.findByIdAndUserIdAndCustomerId(invoiceId, userId, customerId)
+                .orElseThrow(() -> new IllegalArgumentException("Invoice not found"));
+
+        InvoiceItemEntity entity = invoiceItemRepository.findByIdAndInvoiceId(itemId, invoiceId)
+                .orElseThrow(() -> new IllegalArgumentException("Item not found"));
+        invoiceItemRepository.delete(entity);
+        return toDomain(entity);
+    }
+
+    private InvoiceItem toDomain(InvoiceItemEntity entity) {
+        return new InvoiceItem(
+                entity.getId().toString(),
+                entity.getDescription(),
+                entity.getQuantity(),
+                entity.getUnitPrice(),
+                entity.getTotalPrice()
+        );
+    }
+}

--- a/backend/src/main/java/org/example/backend/user/controller/UserController.java
+++ b/backend/src/main/java/org/example/backend/user/controller/UserController.java
@@ -1,0 +1,37 @@
+package org.example.backend.user.controller;
+
+import org.example.backend.user.domain.User;
+import org.example.backend.user.dto.CreateUserRequest;
+import org.example.backend.user.service.UserService;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.server.ResponseStatusException;
+
+import jakarta.validation.Valid;
+
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/users")
+public class UserController {
+    private final UserService userService;
+
+    public UserController(UserService userService) {
+        this.userService = userService;
+    }
+
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    public User createUser(@Valid @RequestBody CreateUserRequest request) {
+        try {
+            return userService.createUser(request);
+        } catch (IllegalArgumentException e) {
+            throw new ResponseStatusException(HttpStatus.CONFLICT, e.getMessage(), e);
+        }
+    }
+
+    @DeleteMapping("/{id}")
+    public User deleteUser(@PathVariable String id) {
+        return userService.deleteUser(UUID.fromString(id));
+    }
+}

--- a/backend/src/main/java/org/example/backend/user/domain/User.java
+++ b/backend/src/main/java/org/example/backend/user/domain/User.java
@@ -1,0 +1,4 @@
+package org.example.backend.user.domain;
+
+public record User(String id, String email) {
+}

--- a/backend/src/main/java/org/example/backend/user/dto/CreateUserRequest.java
+++ b/backend/src/main/java/org/example/backend/user/dto/CreateUserRequest.java
@@ -1,0 +1,9 @@
+package org.example.backend.user.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record CreateUserRequest(
+        @NotBlank String email,
+        @NotBlank String password
+) {
+}

--- a/backend/src/main/java/org/example/backend/user/entity/UserEntity.java
+++ b/backend/src/main/java/org/example/backend/user/entity/UserEntity.java
@@ -1,0 +1,78 @@
+package org.example.backend.user.entity;
+
+import jakarta.persistence.*;
+
+import java.time.Instant;
+import java.util.UUID;
+
+@Entity
+@Table(name = "users")
+public class UserEntity {
+    @Id
+    @GeneratedValue
+    private UUID id;
+
+    @Column(nullable = false, unique = true)
+    private String email;
+
+    @Column(name = "password_hash", nullable = false)
+    private String passwordHash;
+
+    @Column(name = "created_at", updatable = false)
+    private Instant createdAt;
+
+    @Column(name = "updated_at")
+    private Instant updatedAt;
+
+    @PrePersist
+    public void prePersist() {
+        Instant now = Instant.now();
+        this.createdAt = now;
+        this.updatedAt = now;
+    }
+
+    @PreUpdate
+    public void preUpdate() {
+        this.updatedAt = Instant.now();
+    }
+
+    public UUID getId() {
+        return id;
+    }
+
+    public void setId(UUID id) {
+        this.id = id;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public void setEmail(String email) {
+        this.email = email;
+    }
+
+    public String getPasswordHash() {
+        return passwordHash;
+    }
+
+    public void setPasswordHash(String passwordHash) {
+        this.passwordHash = passwordHash;
+    }
+
+    public Instant getCreatedAt() {
+        return createdAt;
+    }
+
+    public void setCreatedAt(Instant createdAt) {
+        this.createdAt = createdAt;
+    }
+
+    public Instant getUpdatedAt() {
+        return updatedAt;
+    }
+
+    public void setUpdatedAt(Instant updatedAt) {
+        this.updatedAt = updatedAt;
+    }
+}

--- a/backend/src/main/java/org/example/backend/user/repository/UserRepository.java
+++ b/backend/src/main/java/org/example/backend/user/repository/UserRepository.java
@@ -1,0 +1,10 @@
+package org.example.backend.user.repository;
+
+import org.example.backend.user.entity.UserEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.UUID;
+
+public interface UserRepository extends JpaRepository<UserEntity, UUID> {
+    boolean existsByEmail(String email);
+}

--- a/backend/src/main/java/org/example/backend/user/service/UserService.java
+++ b/backend/src/main/java/org/example/backend/user/service/UserService.java
@@ -1,0 +1,37 @@
+package org.example.backend.user.service;
+
+import org.example.backend.user.domain.User;
+import org.example.backend.user.dto.CreateUserRequest;
+import org.example.backend.user.entity.UserEntity;
+import org.example.backend.user.repository.UserRepository;
+import org.springframework.stereotype.Service;
+
+import java.util.UUID;
+
+@Service
+public class UserService {
+    private final UserRepository userRepository;
+
+    public UserService(UserRepository userRepository) {
+        this.userRepository = userRepository;
+    }
+
+    public User createUser(CreateUserRequest request) {
+        if (userRepository.existsByEmail(request.email())) {
+            throw new IllegalArgumentException("User already exists");
+        }
+
+        UserEntity entity = new UserEntity();
+        entity.setEmail(request.email());
+        entity.setPasswordHash(request.password());
+        UserEntity saved = userRepository.save(entity);
+        return new User(saved.getId().toString(), saved.getEmail());
+    }
+
+    public User deleteUser(UUID id) {
+        UserEntity entity = userRepository.findById(id)
+                .orElseThrow(() -> new IllegalArgumentException("User not found"));
+        userRepository.delete(entity);
+        return new User(entity.getId().toString(), entity.getEmail());
+    }
+}

--- a/backend/src/test/java/org/example/backend/customer/CustomerIntegrationTest.java
+++ b/backend/src/test/java/org/example/backend/customer/CustomerIntegrationTest.java
@@ -1,0 +1,63 @@
+package org.example.backend.customer;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.example.backend.customer.dto.CreateCustomerRequest;
+import org.example.backend.customer.dto.UpdateCustomerRequest;
+import org.example.backend.user.entity.UserEntity;
+import org.example.backend.user.repository.UserRepository;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.UUID;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+class CustomerIntegrationTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Test
+    void createUpdateDeleteCustomerFlow() throws Exception {
+        UserEntity user = new UserEntity();
+        user.setEmail("test@example.com");
+        user.setPasswordHash("pw");
+        user = userRepository.save(user);
+        UUID userId = user.getId();
+
+        CreateCustomerRequest createRequest = new CreateCustomerRequest("John", "123", "john@example.com", "Street");
+        String createResponse = mockMvc.perform(post("/user/{userId}/customer", userId.toString())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(createRequest)))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.id").isNotEmpty())
+                .andReturn().getResponse().getContentAsString();
+        String customerId = objectMapper.readTree(createResponse).get("id").asText();
+
+        UpdateCustomerRequest updateRequest = new UpdateCustomerRequest("Jane", "456", "jane@example.com", "Road");
+        mockMvc.perform(put("/user/{userId}/customer/{customerId}", userId.toString(), customerId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(updateRequest)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.name").value("Jane"));
+
+        mockMvc.perform(delete("/user/{userId}/customer/{customerId}", userId.toString(), customerId))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value(customerId));
+    }
+}

--- a/backend/src/test/java/org/example/backend/customer/controller/CustomerControllerTest.java
+++ b/backend/src/test/java/org/example/backend/customer/controller/CustomerControllerTest.java
@@ -1,0 +1,73 @@
+package org.example.backend.customer.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.example.backend.customer.domain.Customer;
+import org.example.backend.customer.dto.CreateCustomerRequest;
+import org.example.backend.customer.dto.UpdateCustomerRequest;
+import org.example.backend.customer.service.CustomerService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.UUID;
+
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(CustomerController.class)
+class CustomerControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private CustomerService customerService;
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Test
+    void createCustomerReturnsCreatedCustomer() throws Exception {
+        UUID userId = UUID.randomUUID();
+        CreateCustomerRequest request = new CreateCustomerRequest("John", "123", "j@example.com", "Street");
+        Customer response = new Customer(UUID.randomUUID().toString(), "John", "123", "j@example.com", "Street");
+        given(customerService.createCustomer(eq(userId), any(CreateCustomerRequest.class))).willReturn(response);
+
+        mockMvc.perform(post("/user/{userId}/customer", userId.toString())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.name").value("John"));
+    }
+
+    @Test
+    void updateCustomerReturnsUpdatedCustomer() throws Exception {
+        UUID userId = UUID.randomUUID();
+        UUID customerId = UUID.randomUUID();
+        UpdateCustomerRequest request = new UpdateCustomerRequest("Jane", "456", "j2@example.com", "Road");
+        Customer response = new Customer(customerId.toString(), "Jane", "456", "j2@example.com", "Road");
+        given(customerService.updateCustomer(eq(userId), eq(customerId), any(UpdateCustomerRequest.class))).willReturn(response);
+
+        mockMvc.perform(put("/user/{userId}/customer/{customerId}", userId.toString(), customerId.toString())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.name").value("Jane"));
+    }
+
+    @Test
+    void deleteCustomerReturnsDeletedCustomer() throws Exception {
+        UUID userId = UUID.randomUUID();
+        UUID customerId = UUID.randomUUID();
+        Customer response = new Customer(customerId.toString(), "Del", "1", "e", "a");
+        given(customerService.deleteCustomer(userId, customerId)).willReturn(response);
+
+        mockMvc.perform(delete("/user/{userId}/customer/{customerId}", userId.toString(), customerId.toString()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value(customerId.toString()));
+    }
+}

--- a/backend/src/test/java/org/example/backend/customer/controller/CustomerControllerTest.java
+++ b/backend/src/test/java/org/example/backend/customer/controller/CustomerControllerTest.java
@@ -28,7 +28,7 @@ class CustomerControllerTest {
     @MockBean
     private CustomerService customerService;
 
-    private final ObjectMapper objectMapper = new ObjectMapper();
+    private final ObjectMapper objectMapper = new ObjectMapper().findAndRegisterModules();
 
     @Test
     void createCustomerReturnsCreatedCustomer() throws Exception {

--- a/backend/src/test/java/org/example/backend/customer/service/CustomerServiceTest.java
+++ b/backend/src/test/java/org/example/backend/customer/service/CustomerServiceTest.java
@@ -1,0 +1,83 @@
+package org.example.backend.customer.service;
+
+import org.example.backend.customer.domain.Customer;
+import org.example.backend.customer.dto.CreateCustomerRequest;
+import org.example.backend.customer.dto.UpdateCustomerRequest;
+import org.example.backend.customer.entity.CustomerEntity;
+import org.example.backend.customer.repository.CustomerRepository;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+class CustomerServiceTest {
+
+    private final CustomerRepository customerRepository = mock(CustomerRepository.class);
+    private final CustomerService customerService = new CustomerService(customerRepository);
+
+    @Test
+    void createCustomerSavesAndReturnsDomain() {
+        UUID userId = UUID.randomUUID();
+        CreateCustomerRequest request = new CreateCustomerRequest("John", "123", "j@example.com", "Street");
+
+        CustomerEntity savedEntity = new CustomerEntity();
+        savedEntity.setId(UUID.randomUUID());
+        savedEntity.setUserId(userId);
+        savedEntity.setName("John");
+        savedEntity.setPhone("123");
+        savedEntity.setEmail("j@example.com");
+        savedEntity.setAddress("Street");
+
+        when(customerRepository.save(any(CustomerEntity.class))).thenReturn(savedEntity);
+
+        Customer result = customerService.createCustomer(userId, request);
+
+        ArgumentCaptor<CustomerEntity> captor = ArgumentCaptor.forClass(CustomerEntity.class);
+        verify(customerRepository).save(captor.capture());
+        assertEquals("John", captor.getValue().getName());
+        assertEquals(savedEntity.getId().toString(), result.id());
+    }
+
+    @Test
+    void updateCustomerUpdatesFields() {
+        UUID userId = UUID.randomUUID();
+        UUID customerId = UUID.randomUUID();
+        UpdateCustomerRequest request = new UpdateCustomerRequest("Jane", "456", "j2@example.com", "Road");
+
+        CustomerEntity entity = new CustomerEntity();
+        entity.setId(customerId);
+        entity.setUserId(userId);
+        entity.setName("Old");
+
+        when(customerRepository.findByIdAndUserId(customerId, userId)).thenReturn(Optional.of(entity));
+        when(customerRepository.save(entity)).thenReturn(entity);
+
+        Customer result = customerService.updateCustomer(userId, customerId, request);
+
+        assertEquals("Jane", entity.getName());
+        verify(customerRepository).save(entity);
+        assertEquals(customerId.toString(), result.id());
+        assertEquals("Jane", result.name());
+    }
+
+    @Test
+    void deleteCustomerDeletesEntity() {
+        UUID userId = UUID.randomUUID();
+        UUID customerId = UUID.randomUUID();
+        CustomerEntity entity = new CustomerEntity();
+        entity.setId(customerId);
+        entity.setUserId(userId);
+        entity.setName("Del");
+
+        when(customerRepository.findByIdAndUserId(customerId, userId)).thenReturn(Optional.of(entity));
+
+        Customer result = customerService.deleteCustomer(userId, customerId);
+
+        verify(customerRepository).delete(entity);
+        assertEquals(customerId.toString(), result.id());
+    }
+}

--- a/backend/src/test/java/org/example/backend/invoice/InvoiceIntegrationTest.java
+++ b/backend/src/test/java/org/example/backend/invoice/InvoiceIntegrationTest.java
@@ -1,0 +1,76 @@
+package org.example.backend.invoice;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.example.backend.customer.entity.CustomerEntity;
+import org.example.backend.customer.repository.CustomerRepository;
+import org.example.backend.invoice.dto.CreateInvoiceRequest;
+import org.example.backend.invoice.dto.UpdateInvoiceRequest;
+import org.example.backend.user.entity.UserEntity;
+import org.example.backend.user.repository.UserRepository;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.UUID;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+class InvoiceIntegrationTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private CustomerRepository customerRepository;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Test
+    void createUpdateDeleteInvoiceFlow() throws Exception {
+        UserEntity user = new UserEntity();
+        user.setEmail("test@example.com");
+        user.setPasswordHash("pw");
+        user = userRepository.save(user);
+        UUID userId = user.getId();
+
+        CustomerEntity customer = new CustomerEntity();
+        customer.setUserId(userId);
+        customer.setName("Cust");
+        customer = customerRepository.save(customer);
+        UUID customerId = customer.getId();
+
+        CreateInvoiceRequest createRequest = new CreateInvoiceRequest("INV-1", LocalDate.now(), null, "unpaid", BigDecimal.ONE, BigDecimal.TEN, BigDecimal.valueOf(11), "note");
+        String createResponse = mockMvc.perform(post("/user/{userId}/customer/{customerId}/invoice", userId.toString(), customerId.toString())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(createRequest)))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.id").isNotEmpty())
+                .andReturn().getResponse().getContentAsString();
+        String invoiceId = objectMapper.readTree(createResponse).get("id").asText();
+
+        UpdateInvoiceRequest updateRequest = new UpdateInvoiceRequest("INV-2", LocalDate.now(), null, "paid", BigDecimal.ONE, BigDecimal.TEN, BigDecimal.valueOf(11), "note");
+        mockMvc.perform(put("/user/{userId}/customer/{customerId}/invoice/{invoiceId}", userId.toString(), customerId.toString(), invoiceId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(updateRequest)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.invoiceNumber").value("INV-2"));
+
+        mockMvc.perform(delete("/user/{userId}/customer/{customerId}/invoice/{invoiceId}", userId.toString(), customerId.toString(), invoiceId))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value(invoiceId));
+    }
+}

--- a/backend/src/test/java/org/example/backend/invoice/InvoiceIntegrationTest.java
+++ b/backend/src/test/java/org/example/backend/invoice/InvoiceIntegrationTest.java
@@ -42,7 +42,7 @@ class InvoiceIntegrationTest {
     @Test
     void createUpdateDeleteInvoiceFlow() throws Exception {
         UserEntity user = new UserEntity();
-        user.setEmail("test@example.com");
+        user.setEmail("test1@example.com");
         user.setPasswordHash("pw");
         user = userRepository.save(user);
         UUID userId = user.getId();

--- a/backend/src/test/java/org/example/backend/invoice/controller/InvoiceControllerTest.java
+++ b/backend/src/test/java/org/example/backend/invoice/controller/InvoiceControllerTest.java
@@ -30,7 +30,7 @@ class InvoiceControllerTest {
     @MockBean
     private InvoiceService invoiceService;
 
-    private final ObjectMapper objectMapper = new ObjectMapper();
+    private final ObjectMapper objectMapper = new ObjectMapper().findAndRegisterModules();
 
     @Test
     void createInvoiceReturnsCreatedInvoice() throws Exception {

--- a/backend/src/test/java/org/example/backend/invoice/controller/InvoiceControllerTest.java
+++ b/backend/src/test/java/org/example/backend/invoice/controller/InvoiceControllerTest.java
@@ -1,0 +1,78 @@
+package org.example.backend.invoice.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.example.backend.invoice.domain.Invoice;
+import org.example.backend.invoice.dto.CreateInvoiceRequest;
+import org.example.backend.invoice.dto.UpdateInvoiceRequest;
+import org.example.backend.invoice.service.InvoiceService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.UUID;
+
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(InvoiceController.class)
+class InvoiceControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private InvoiceService invoiceService;
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Test
+    void createInvoiceReturnsCreatedInvoice() throws Exception {
+        UUID userId = UUID.randomUUID();
+        UUID customerId = UUID.randomUUID();
+        CreateInvoiceRequest request = new CreateInvoiceRequest("INV-1", LocalDate.now(), null, "unpaid", BigDecimal.ONE, BigDecimal.TEN, BigDecimal.valueOf(11), "note");
+        Invoice response = new Invoice(UUID.randomUUID().toString(), "INV-1", LocalDate.now(), null, "unpaid", BigDecimal.ONE, BigDecimal.TEN, BigDecimal.valueOf(11), "note");
+        given(invoiceService.createInvoice(eq(userId), eq(customerId), any(CreateInvoiceRequest.class))).willReturn(response);
+
+        mockMvc.perform(post("/user/{userId}/customer/{customerId}/invoice", userId.toString(), customerId.toString())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.invoiceNumber").value("INV-1"));
+    }
+
+    @Test
+    void updateInvoiceReturnsUpdatedInvoice() throws Exception {
+        UUID userId = UUID.randomUUID();
+        UUID customerId = UUID.randomUUID();
+        UUID invoiceId = UUID.randomUUID();
+        UpdateInvoiceRequest request = new UpdateInvoiceRequest("INV-2", LocalDate.now(), null, "paid", BigDecimal.ONE, BigDecimal.TEN, BigDecimal.valueOf(11), "note");
+        Invoice response = new Invoice(invoiceId.toString(), "INV-2", LocalDate.now(), null, "paid", BigDecimal.ONE, BigDecimal.TEN, BigDecimal.valueOf(11), "note");
+        given(invoiceService.updateInvoice(eq(userId), eq(customerId), eq(invoiceId), any(UpdateInvoiceRequest.class))).willReturn(response);
+
+        mockMvc.perform(put("/user/{userId}/customer/{customerId}/invoice/{invoiceId}", userId.toString(), customerId.toString(), invoiceId.toString())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.invoiceNumber").value("INV-2"));
+    }
+
+    @Test
+    void deleteInvoiceReturnsDeletedInvoice() throws Exception {
+        UUID userId = UUID.randomUUID();
+        UUID customerId = UUID.randomUUID();
+        UUID invoiceId = UUID.randomUUID();
+        Invoice response = new Invoice(invoiceId.toString(), "INV-3", LocalDate.now(), null, "unpaid", BigDecimal.ONE, BigDecimal.TEN, BigDecimal.valueOf(11), "note");
+        given(invoiceService.deleteInvoice(userId, customerId, invoiceId)).willReturn(response);
+
+        mockMvc.perform(delete("/user/{userId}/customer/{customerId}/invoice/{invoiceId}", userId.toString(), customerId.toString(), invoiceId.toString()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value(invoiceId.toString()));
+    }
+}

--- a/backend/src/test/java/org/example/backend/invoice/service/InvoiceServiceTest.java
+++ b/backend/src/test/java/org/example/backend/invoice/service/InvoiceServiceTest.java
@@ -1,0 +1,120 @@
+package org.example.backend.invoice.service;
+
+import org.example.backend.customer.entity.CustomerEntity;
+import org.example.backend.customer.repository.CustomerRepository;
+import org.example.backend.invoice.domain.Invoice;
+import org.example.backend.invoice.dto.CreateInvoiceRequest;
+import org.example.backend.invoice.dto.UpdateInvoiceRequest;
+import org.example.backend.invoice.entity.InvoiceEntity;
+import org.example.backend.invoice.repository.InvoiceRepository;
+import org.example.backend.user.repository.UserRepository;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+class InvoiceServiceTest {
+
+    private final InvoiceRepository invoiceRepository = mock(InvoiceRepository.class);
+    private final UserRepository userRepository = mock(UserRepository.class);
+    private final CustomerRepository customerRepository = mock(CustomerRepository.class);
+    private final InvoiceService invoiceService = new InvoiceService(invoiceRepository, userRepository, customerRepository);
+
+    @Test
+    void createInvoiceSavesAndReturnsDomain() {
+        UUID userId = UUID.randomUUID();
+        UUID customerId = UUID.randomUUID();
+        CreateInvoiceRequest request = new CreateInvoiceRequest(
+                "INV-1",
+                LocalDate.now(),
+                LocalDate.now().plusDays(10),
+                "unpaid",
+                BigDecimal.ONE,
+                BigDecimal.TEN,
+                BigDecimal.valueOf(11),
+                "note"
+        );
+
+        when(userRepository.existsById(userId)).thenReturn(true);
+        when(customerRepository.findByIdAndUserId(customerId, userId)).thenReturn(Optional.of(new CustomerEntity()));
+
+        InvoiceEntity saved = new InvoiceEntity();
+        saved.setId(UUID.randomUUID());
+        saved.setUserId(userId);
+        saved.setCustomerId(customerId);
+        saved.setInvoiceNumber("INV-1");
+        saved.setIssueDate(request.issueDate());
+        saved.setDueDate(request.dueDate());
+        saved.setStatus(request.status());
+        saved.setTaxAmount(request.taxAmount());
+        saved.setSubtotal(request.subtotal());
+        saved.setTotal(request.total());
+        saved.setNotes(request.notes());
+
+        when(invoiceRepository.save(any(InvoiceEntity.class))).thenReturn(saved);
+
+        Invoice result = invoiceService.createInvoice(userId, customerId, request);
+
+        ArgumentCaptor<InvoiceEntity> captor = ArgumentCaptor.forClass(InvoiceEntity.class);
+        verify(invoiceRepository).save(captor.capture());
+        assertEquals("INV-1", captor.getValue().getInvoiceNumber());
+        assertEquals(saved.getId().toString(), result.id());
+    }
+
+    @Test
+    void updateInvoiceUpdatesFields() {
+        UUID userId = UUID.randomUUID();
+        UUID customerId = UUID.randomUUID();
+        UUID invoiceId = UUID.randomUUID();
+        UpdateInvoiceRequest request = new UpdateInvoiceRequest(
+                "INV-2",
+                LocalDate.now(),
+                LocalDate.now().plusDays(5),
+                "paid",
+                BigDecimal.ONE,
+                BigDecimal.TEN,
+                BigDecimal.valueOf(11),
+                "n2"
+        );
+
+        InvoiceEntity entity = new InvoiceEntity();
+        entity.setId(invoiceId);
+        entity.setUserId(userId);
+        entity.setCustomerId(customerId);
+        entity.setInvoiceNumber("OLD");
+
+        when(invoiceRepository.findByIdAndUserIdAndCustomerId(invoiceId, userId, customerId)).thenReturn(Optional.of(entity));
+        when(invoiceRepository.save(entity)).thenReturn(entity);
+
+        Invoice result = invoiceService.updateInvoice(userId, customerId, invoiceId, request);
+
+        assertEquals("INV-2", entity.getInvoiceNumber());
+        verify(invoiceRepository).save(entity);
+        assertEquals(invoiceId.toString(), result.id());
+    }
+
+    @Test
+    void deleteInvoiceDeletesEntity() {
+        UUID userId = UUID.randomUUID();
+        UUID customerId = UUID.randomUUID();
+        UUID invoiceId = UUID.randomUUID();
+        InvoiceEntity entity = new InvoiceEntity();
+        entity.setId(invoiceId);
+        entity.setUserId(userId);
+        entity.setCustomerId(customerId);
+        entity.setInvoiceNumber("INV");
+
+        when(invoiceRepository.findByIdAndUserIdAndCustomerId(invoiceId, userId, customerId)).thenReturn(Optional.of(entity));
+
+        Invoice result = invoiceService.deleteInvoice(userId, customerId, invoiceId);
+
+        verify(invoiceRepository).delete(entity);
+        assertEquals(invoiceId.toString(), result.id());
+    }
+}

--- a/backend/src/test/java/org/example/backend/invoiceitem/InvoiceItemIntegrationTest.java
+++ b/backend/src/test/java/org/example/backend/invoiceitem/InvoiceItemIntegrationTest.java
@@ -1,0 +1,90 @@
+package org.example.backend.invoiceitem;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.example.backend.customer.entity.CustomerEntity;
+import org.example.backend.customer.repository.CustomerRepository;
+import org.example.backend.invoice.entity.InvoiceEntity;
+import org.example.backend.invoice.repository.InvoiceRepository;
+import org.example.backend.invoiceitem.dto.CreateInvoiceItemRequest;
+import org.example.backend.invoiceitem.dto.UpdateInvoiceItemRequest;
+import org.example.backend.user.entity.UserEntity;
+import org.example.backend.user.repository.UserRepository;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.UUID;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+class InvoiceItemIntegrationTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private CustomerRepository customerRepository;
+
+    @Autowired
+    private InvoiceRepository invoiceRepository;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Test
+    void createUpdateDeleteItemFlow() throws Exception {
+        UserEntity user = new UserEntity();
+        user.setEmail("item@example.com");
+        user.setPasswordHash("pw");
+        user = userRepository.save(user);
+        UUID userId = user.getId();
+
+        CustomerEntity customer = new CustomerEntity();
+        customer.setUserId(userId);
+        customer.setName("CustI");
+        customer = customerRepository.save(customer);
+        UUID customerId = customer.getId();
+
+        InvoiceEntity invoice = new InvoiceEntity();
+        invoice.setUserId(userId);
+        invoice.setCustomerId(customerId);
+        invoice.setInvoiceNumber("INV-ITEM-1");
+        invoice.setIssueDate(LocalDate.now());
+        invoice.setStatus("unpaid");
+        invoice = invoiceRepository.save(invoice);
+        UUID invoiceId = invoice.getId();
+
+        CreateInvoiceItemRequest createRequest = new CreateInvoiceItemRequest("desc", 2, BigDecimal.TEN);
+        String createResponse = mockMvc.perform(post("/user/{userId}/customer/{customerId}/invoice/{invoiceId}/item", userId.toString(), customerId.toString(), invoiceId.toString())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(createRequest)))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.id").isNotEmpty())
+                .andReturn().getResponse().getContentAsString();
+        String itemId = objectMapper.readTree(createResponse).get("id").asText();
+
+        UpdateInvoiceItemRequest updateRequest = new UpdateInvoiceItemRequest("new", 3, BigDecimal.ONE);
+        mockMvc.perform(put("/user/{userId}/customer/{customerId}/invoice/{invoiceId}/item/{itemId}", userId.toString(), customerId.toString(), invoiceId.toString(), itemId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(updateRequest)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.description").value("new"));
+
+        mockMvc.perform(delete("/user/{userId}/customer/{customerId}/invoice/{invoiceId}/item/{itemId}", userId.toString(), customerId.toString(), invoiceId.toString(), itemId))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value(itemId));
+    }
+}

--- a/backend/src/test/java/org/example/backend/invoiceitem/controller/InvoiceItemControllerTest.java
+++ b/backend/src/test/java/org/example/backend/invoiceitem/controller/InvoiceItemControllerTest.java
@@ -1,0 +1,82 @@
+package org.example.backend.invoiceitem.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.example.backend.invoiceitem.domain.InvoiceItem;
+import org.example.backend.invoiceitem.dto.CreateInvoiceItemRequest;
+import org.example.backend.invoiceitem.dto.UpdateInvoiceItemRequest;
+import org.example.backend.invoiceitem.service.InvoiceItemService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.math.BigDecimal;
+import java.util.UUID;
+
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(InvoiceItemController.class)
+class InvoiceItemControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private InvoiceItemService invoiceItemService;
+
+    private final ObjectMapper objectMapper = new ObjectMapper().findAndRegisterModules();
+
+    @Test
+    void createItemReturnsCreatedItem() throws Exception {
+        UUID userId = UUID.randomUUID();
+        UUID customerId = UUID.randomUUID();
+        UUID invoiceId = UUID.randomUUID();
+        CreateInvoiceItemRequest request = new CreateInvoiceItemRequest("desc", 2, BigDecimal.TEN);
+        InvoiceItem response = new InvoiceItem(UUID.randomUUID().toString(), "desc", 2, BigDecimal.TEN, BigDecimal.valueOf(20));
+        given(invoiceItemService.createItem(eq(userId), eq(customerId), eq(invoiceId), any(CreateInvoiceItemRequest.class))).willReturn(response);
+
+        mockMvc.perform(post("/user/{userId}/customer/{customerId}/invoice/{invoiceId}/item", userId.toString(), customerId.toString(), invoiceId.toString())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.description").value("desc"));
+    }
+
+    @Test
+    void updateItemReturnsUpdatedItem() throws Exception {
+        UUID userId = UUID.randomUUID();
+        UUID customerId = UUID.randomUUID();
+        UUID invoiceId = UUID.randomUUID();
+        UUID itemId = UUID.randomUUID();
+        UpdateInvoiceItemRequest request = new UpdateInvoiceItemRequest("new", 3, BigDecimal.ONE);
+        InvoiceItem response = new InvoiceItem(itemId.toString(), "new", 3, BigDecimal.ONE, BigDecimal.valueOf(3));
+        given(invoiceItemService.updateItem(eq(userId), eq(customerId), eq(invoiceId), eq(itemId), any(UpdateInvoiceItemRequest.class))).willReturn(response);
+
+        mockMvc.perform(put("/user/{userId}/customer/{customerId}/invoice/{invoiceId}/item/{itemId}",
+                        userId.toString(), customerId.toString(), invoiceId.toString(), itemId.toString())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.description").value("new"));
+    }
+
+    @Test
+    void deleteItemReturnsDeletedItem() throws Exception {
+        UUID userId = UUID.randomUUID();
+        UUID customerId = UUID.randomUUID();
+        UUID invoiceId = UUID.randomUUID();
+        UUID itemId = UUID.randomUUID();
+        InvoiceItem response = new InvoiceItem(itemId.toString(), "d", 1, BigDecimal.ONE, BigDecimal.ONE);
+        given(invoiceItemService.deleteItem(userId, customerId, invoiceId, itemId)).willReturn(response);
+
+        mockMvc.perform(delete("/user/{userId}/customer/{customerId}/invoice/{invoiceId}/item/{itemId}",
+                        userId.toString(), customerId.toString(), invoiceId.toString(), itemId.toString()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value(itemId.toString()));
+    }
+}

--- a/backend/src/test/java/org/example/backend/invoiceitem/service/InvoiceItemServiceTest.java
+++ b/backend/src/test/java/org/example/backend/invoiceitem/service/InvoiceItemServiceTest.java
@@ -1,0 +1,104 @@
+package org.example.backend.invoiceitem.service;
+
+import org.example.backend.invoice.entity.InvoiceEntity;
+import org.example.backend.invoice.repository.InvoiceRepository;
+import org.example.backend.invoiceitem.domain.InvoiceItem;
+import org.example.backend.invoiceitem.dto.CreateInvoiceItemRequest;
+import org.example.backend.invoiceitem.dto.UpdateInvoiceItemRequest;
+import org.example.backend.invoiceitem.entity.InvoiceItemEntity;
+import org.example.backend.invoiceitem.repository.InvoiceItemRepository;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.math.BigDecimal;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+class InvoiceItemServiceTest {
+
+    private final InvoiceItemRepository invoiceItemRepository = mock(InvoiceItemRepository.class);
+    private final InvoiceRepository invoiceRepository = mock(InvoiceRepository.class);
+    private final InvoiceItemService invoiceItemService = new InvoiceItemService(invoiceItemRepository, invoiceRepository);
+
+    @Test
+    void createItemSavesAndReturnsDomain() {
+        UUID userId = UUID.randomUUID();
+        UUID customerId = UUID.randomUUID();
+        UUID invoiceId = UUID.randomUUID();
+        CreateInvoiceItemRequest request = new CreateInvoiceItemRequest("desc", 2, BigDecimal.TEN);
+
+        when(invoiceRepository.findByIdAndUserIdAndCustomerId(invoiceId, userId, customerId))
+                .thenReturn(Optional.of(new InvoiceEntity()));
+
+        InvoiceItemEntity saved = new InvoiceItemEntity();
+        saved.setId(UUID.randomUUID());
+        saved.setInvoiceId(invoiceId);
+        saved.setDescription("desc");
+        saved.setQuantity(2);
+        saved.setUnitPrice(BigDecimal.TEN);
+        saved.setTotalPrice(BigDecimal.valueOf(20));
+
+        when(invoiceItemRepository.save(any(InvoiceItemEntity.class))).thenReturn(saved);
+
+        InvoiceItem result = invoiceItemService.createItem(userId, customerId, invoiceId, request);
+
+        ArgumentCaptor<InvoiceItemEntity> captor = ArgumentCaptor.forClass(InvoiceItemEntity.class);
+        verify(invoiceItemRepository).save(captor.capture());
+        assertEquals("desc", captor.getValue().getDescription());
+        assertEquals(saved.getId().toString(), result.id());
+    }
+
+    @Test
+    void updateItemUpdatesFields() {
+        UUID userId = UUID.randomUUID();
+        UUID customerId = UUID.randomUUID();
+        UUID invoiceId = UUID.randomUUID();
+        UUID itemId = UUID.randomUUID();
+        UpdateInvoiceItemRequest request = new UpdateInvoiceItemRequest("new", 3, BigDecimal.ONE);
+
+        when(invoiceRepository.findByIdAndUserIdAndCustomerId(invoiceId, userId, customerId))
+                .thenReturn(Optional.of(new InvoiceEntity()));
+
+        InvoiceItemEntity entity = new InvoiceItemEntity();
+        entity.setId(itemId);
+        entity.setInvoiceId(invoiceId);
+        entity.setDescription("old");
+        entity.setQuantity(1);
+        entity.setUnitPrice(BigDecimal.TEN);
+
+        when(invoiceItemRepository.findByIdAndInvoiceId(itemId, invoiceId)).thenReturn(Optional.of(entity));
+        when(invoiceItemRepository.save(entity)).thenReturn(entity);
+
+        InvoiceItem result = invoiceItemService.updateItem(userId, customerId, invoiceId, itemId, request);
+
+        assertEquals("new", entity.getDescription());
+        verify(invoiceItemRepository).save(entity);
+        assertEquals(itemId.toString(), result.id());
+    }
+
+    @Test
+    void deleteItemDeletesEntity() {
+        UUID userId = UUID.randomUUID();
+        UUID customerId = UUID.randomUUID();
+        UUID invoiceId = UUID.randomUUID();
+        UUID itemId = UUID.randomUUID();
+
+        when(invoiceRepository.findByIdAndUserIdAndCustomerId(invoiceId, userId, customerId))
+                .thenReturn(Optional.of(new InvoiceEntity()));
+
+        InvoiceItemEntity entity = new InvoiceItemEntity();
+        entity.setId(itemId);
+        entity.setInvoiceId(invoiceId);
+        entity.setDescription("d");
+
+        when(invoiceItemRepository.findByIdAndInvoiceId(itemId, invoiceId)).thenReturn(Optional.of(entity));
+
+        InvoiceItem result = invoiceItemService.deleteItem(userId, customerId, invoiceId, itemId);
+
+        verify(invoiceItemRepository).delete(entity);
+        assertEquals(itemId.toString(), result.id());
+    }
+}

--- a/backend/src/test/java/org/example/backend/user/UserIntegrationTest.java
+++ b/backend/src/test/java/org/example/backend/user/UserIntegrationTest.java
@@ -1,0 +1,53 @@
+package org.example.backend.user;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+class UserIntegrationTest {
+    @Autowired
+    private MockMvc mockMvc;
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Test
+    void createAndDeleteUser() throws Exception {
+        MvcResult result = mockMvc.perform(post("/users")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"email\":\"integration@example.com\",\"password\":\"pass\"}"))
+                .andExpect(status().isCreated())
+                .andReturn();
+
+        String id = objectMapper.readTree(result.getResponse().getContentAsString()).get("id").asText();
+
+        mockMvc.perform(delete("/users/" + id))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value(id));
+    }
+
+    @Test
+    void createUserDuplicateEmail() throws Exception {
+        String body = "{\"email\":\"dup@example.com\",\"password\":\"pass\"}";
+        mockMvc.perform(post("/users")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isCreated());
+
+        mockMvc.perform(post("/users")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isConflict());
+    }
+}

--- a/backend/src/test/java/org/example/backend/user/controller/UserControllerTest.java
+++ b/backend/src/test/java/org/example/backend/user/controller/UserControllerTest.java
@@ -1,0 +1,73 @@
+package org.example.backend.user.controller;
+
+import org.example.backend.user.domain.User;
+import org.example.backend.user.dto.CreateUserRequest;
+import org.example.backend.user.service.UserService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.UUID;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(UserController.class)
+@ActiveProfiles("test")
+class UserControllerTest {
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private UserService userService;
+
+    @Test
+    void createUser() throws Exception {
+        User user = new User("1", "email@example.com");
+        when(userService.createUser(any(CreateUserRequest.class))).thenReturn(user);
+
+        mockMvc.perform(post("/users")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"email\":\"email@example.com\",\"password\":\"pass\"}"))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.id").value("1"))
+                .andExpect(jsonPath("$.email").value("email@example.com"));
+    }
+
+    @Test
+    void createUserValidationError() throws Exception {
+        mockMvc.perform(post("/users")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"email\":\"\",\"password\":\"\"}"))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void createUserDuplicateEmail() throws Exception {
+        when(userService.createUser(any(CreateUserRequest.class)))
+                .thenThrow(new IllegalArgumentException("User already exists"));
+
+        mockMvc.perform(post("/users")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"email\":\"email@example.com\",\"password\":\"pass\"}"))
+                .andExpect(status().isConflict());
+    }
+
+    @Test
+    void deleteUser() throws Exception {
+        UUID id = UUID.randomUUID();
+        User user = new User(id.toString(), "email@example.com");
+        when(userService.deleteUser(eq(id))).thenReturn(user);
+
+        mockMvc.perform(delete("/users/" + id))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value(id.toString()));
+    }
+}

--- a/backend/src/test/java/org/example/backend/user/repository/UserRepositoryTest.java
+++ b/backend/src/test/java/org/example/backend/user/repository/UserRepositoryTest.java
@@ -1,0 +1,34 @@
+package org.example.backend.user.repository;
+
+import org.example.backend.user.entity.UserEntity;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@DataJpaTest
+@ActiveProfiles("test")
+class UserRepositoryTest {
+    @Autowired
+    private UserRepository userRepository;
+
+    @Test
+    void saveAndDeleteUser() {
+        UserEntity entity = new UserEntity();
+        entity.setEmail("test@example.com");
+        entity.setPasswordHash("secret");
+        UserEntity saved = userRepository.save(entity);
+
+        Optional<UserEntity> found = userRepository.findById(saved.getId());
+        assertTrue(found.isPresent());
+        assertTrue(userRepository.existsByEmail("test@example.com"));
+
+        userRepository.deleteById(saved.getId());
+        assertFalse(userRepository.findById(saved.getId()).isPresent());
+        assertFalse(userRepository.existsByEmail("test@example.com"));
+    }
+}

--- a/backend/src/test/java/org/example/backend/user/service/UserServiceTest.java
+++ b/backend/src/test/java/org/example/backend/user/service/UserServiceTest.java
@@ -1,0 +1,66 @@
+package org.example.backend.user.service;
+
+import org.example.backend.user.domain.User;
+import org.example.backend.user.dto.CreateUserRequest;
+import org.example.backend.user.entity.UserEntity;
+import org.example.backend.user.repository.UserRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class UserServiceTest {
+    @Mock
+    private UserRepository userRepository;
+    @InjectMocks
+    private UserService userService;
+
+    @Test
+    void createUser() {
+        CreateUserRequest request = new CreateUserRequest("email@example.com", "pass");
+        UserEntity saved = new UserEntity();
+        saved.setId(UUID.randomUUID());
+        saved.setEmail("email@example.com");
+        saved.setPasswordHash("pass");
+
+        when(userRepository.save(any(UserEntity.class))).thenReturn(saved);
+
+        User result = userService.createUser(request);
+
+        assertEquals(saved.getId().toString(), result.id());
+        assertEquals("email@example.com", result.email());
+    }
+
+    @Test
+    void createUserDuplicateEmail() {
+        CreateUserRequest request = new CreateUserRequest("email@example.com", "pass");
+        when(userRepository.existsByEmail("email@example.com")).thenReturn(true);
+
+        assertThrows(IllegalArgumentException.class, () -> userService.createUser(request));
+    }
+
+    @Test
+    void deleteUser() {
+        UUID id = UUID.randomUUID();
+        UserEntity entity = new UserEntity();
+        entity.setId(id);
+        entity.setEmail("email@example.com");
+        entity.setPasswordHash("pass");
+
+        when(userRepository.findById(id)).thenReturn(Optional.of(entity));
+
+        User result = userService.deleteUser(id);
+
+        verify(userRepository).delete(entity);
+        assertEquals(id.toString(), result.id());
+    }
+}


### PR DESCRIPTION
## Summary
- add controller/service/repository for invoice items under `/user/{userId}/customer/{customerId}/invoice/{invoiceId}/item`
- validate parent invoice existence and compute item totals
- cover create/update/delete flows with unit and integration tests

## Testing
- `mvn test` *(fails: Non-resolvable parent POM - network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689293ff2b048320a7881dab9fea678b