### PR TITLE
docs: add frontend development guidelines

### DIFF
--- a/frontend/AGENTS.md
+++ b/frontend/AGENTS.md
@@ -1,0 +1,23 @@
+# Frontend Development Guidelines
+
+This document defines conventions for all code in this `frontend` directory.
+
+## UI Components
+
+- Use [shadcn/ui](https://ui.shadcn.com) components for building the interface.
+- All styling should be implemented with Tailwind CSS.
+
+## Mobile First
+
+- Design every page and component with a mobile-first approach.
+- Ensure layouts are responsive, scaling up for larger screens as needed.
+
+## Testing
+
+- Write unit tests for components and hooks using React Testing Library.
+- Provide end-to-end tests, also built with React Testing Library, that exercise user flows.
+
+## Backend Integration
+
+- When calling backend APIs, reference the documentation and implementations in the `backend` directory to understand available endpoints and payloads.
+


### PR DESCRIPTION
## Summary
- add frontend `AGENTS.md` outlining mobile-first development with shadcn components, Tailwind CSS, and testing expectations

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Fast refresh only works when a file only exports components)*
- `./mvnw test` *(fails: Failed to fetch Apache Maven distribution)*

------
https://chatgpt.com/codex/tasks/task_e_6892a4dc3a1483208052c13b8b1b5c7c