### PR TITLE
Add retrieval endpoints and list APIs for backend entities

### DIFF
--- a/backend/src/main/java/org/example/backend/customer/controller/CustomerController.java
+++ b/backend/src/main/java/org/example/backend/customer/controller/CustomerController.java
@@ -10,6 +10,7 @@ import org.springframework.web.server.ResponseStatusException;
 
 import jakarta.validation.Valid;
 
+import java.util.List;
 import java.util.UUID;
 
 @RestController
@@ -26,6 +27,21 @@ public class CustomerController {
     public Customer createCustomer(@PathVariable String userId,
                                    @Valid @RequestBody CreateCustomerRequest request) {
         return customerService.createCustomer(UUID.fromString(userId), request);
+    }
+
+    @GetMapping
+    public List<Customer> getCustomers(@PathVariable String userId) {
+        return customerService.getCustomers(UUID.fromString(userId));
+    }
+
+    @GetMapping("/{customerId}")
+    public Customer getCustomer(@PathVariable String userId,
+                                @PathVariable String customerId) {
+        try {
+            return customerService.getCustomer(UUID.fromString(userId), UUID.fromString(customerId));
+        } catch (IllegalArgumentException e) {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, e.getMessage(), e);
+        }
     }
 
     @PutMapping("/{customerId}")

--- a/backend/src/main/java/org/example/backend/customer/repository/CustomerRepository.java
+++ b/backend/src/main/java/org/example/backend/customer/repository/CustomerRepository.java
@@ -3,9 +3,11 @@ package org.example.backend.customer.repository;
 import org.example.backend.customer.entity.CustomerEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
 public interface CustomerRepository extends JpaRepository<CustomerEntity, UUID> {
     Optional<CustomerEntity> findByIdAndUserId(UUID id, UUID userId);
+    List<CustomerEntity> findAllByUserId(UUID userId);
 }

--- a/backend/src/main/java/org/example/backend/customer/service/CustomerService.java
+++ b/backend/src/main/java/org/example/backend/customer/service/CustomerService.java
@@ -7,6 +7,7 @@ import org.example.backend.customer.entity.CustomerEntity;
 import org.example.backend.customer.repository.CustomerRepository;
 import org.springframework.stereotype.Service;
 
+import java.util.List;
 import java.util.UUID;
 
 @Service
@@ -44,6 +45,18 @@ public class CustomerService {
                 .orElseThrow(() -> new IllegalArgumentException("Customer not found"));
         customerRepository.delete(entity);
         return toDomain(entity);
+    }
+
+    public Customer getCustomer(UUID userId, UUID customerId) {
+        CustomerEntity entity = customerRepository.findByIdAndUserId(customerId, userId)
+                .orElseThrow(() -> new IllegalArgumentException("Customer not found"));
+        return toDomain(entity);
+    }
+
+    public List<Customer> getCustomers(UUID userId) {
+        return customerRepository.findAllByUserId(userId).stream()
+                .map(this::toDomain)
+                .toList();
     }
 
     private Customer toDomain(CustomerEntity entity) {

--- a/backend/src/main/java/org/example/backend/invoice/controller/InvoiceController.java
+++ b/backend/src/main/java/org/example/backend/invoice/controller/InvoiceController.java
@@ -10,6 +10,7 @@ import org.springframework.web.server.ResponseStatusException;
 
 import jakarta.validation.Valid;
 
+import java.util.List;
 import java.util.UUID;
 
 @RestController
@@ -28,6 +29,27 @@ public class InvoiceController {
                                  @Valid @RequestBody CreateInvoiceRequest request) {
         try {
             return invoiceService.createInvoice(UUID.fromString(userId), UUID.fromString(customerId), request);
+        } catch (IllegalArgumentException e) {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, e.getMessage(), e);
+        }
+    }
+
+    @GetMapping
+    public List<Invoice> getInvoices(@PathVariable String userId,
+                                     @PathVariable String customerId) {
+        try {
+            return invoiceService.getInvoices(UUID.fromString(userId), UUID.fromString(customerId));
+        } catch (IllegalArgumentException e) {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, e.getMessage(), e);
+        }
+    }
+
+    @GetMapping("/{invoiceId}")
+    public Invoice getInvoice(@PathVariable String userId,
+                              @PathVariable String customerId,
+                              @PathVariable String invoiceId) {
+        try {
+            return invoiceService.getInvoice(UUID.fromString(userId), UUID.fromString(customerId), UUID.fromString(invoiceId));
         } catch (IllegalArgumentException e) {
             throw new ResponseStatusException(HttpStatus.NOT_FOUND, e.getMessage(), e);
         }

--- a/backend/src/main/java/org/example/backend/invoice/repository/InvoiceRepository.java
+++ b/backend/src/main/java/org/example/backend/invoice/repository/InvoiceRepository.java
@@ -3,9 +3,11 @@ package org.example.backend.invoice.repository;
 import org.example.backend.invoice.entity.InvoiceEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
 public interface InvoiceRepository extends JpaRepository<InvoiceEntity, UUID> {
     Optional<InvoiceEntity> findByIdAndUserIdAndCustomerId(UUID id, UUID userId, UUID customerId);
+    List<InvoiceEntity> findAllByUserIdAndCustomerId(UUID userId, UUID customerId);
 }

--- a/backend/src/main/java/org/example/backend/invoice/service/InvoiceService.java
+++ b/backend/src/main/java/org/example/backend/invoice/service/InvoiceService.java
@@ -9,6 +9,7 @@ import org.example.backend.invoice.repository.InvoiceRepository;
 import org.example.backend.user.repository.UserRepository;
 import org.springframework.stereotype.Service;
 
+import java.util.List;
 import java.util.UUID;
 
 @Service
@@ -67,6 +68,23 @@ public class InvoiceService {
                 .orElseThrow(() -> new IllegalArgumentException("Invoice not found"));
         invoiceRepository.delete(entity);
         return toDomain(entity);
+    }
+
+    public Invoice getInvoice(UUID userId, UUID customerId, UUID invoiceId) {
+        InvoiceEntity entity = invoiceRepository.findByIdAndUserIdAndCustomerId(invoiceId, userId, customerId)
+                .orElseThrow(() -> new IllegalArgumentException("Invoice not found"));
+        return toDomain(entity);
+    }
+
+    public List<Invoice> getInvoices(UUID userId, UUID customerId) {
+        if (!userRepository.existsById(userId)) {
+            throw new IllegalArgumentException("User not found");
+        }
+        customerRepository.findByIdAndUserId(customerId, userId)
+                .orElseThrow(() -> new IllegalArgumentException("Customer not found"));
+        return invoiceRepository.findAllByUserIdAndCustomerId(userId, customerId).stream()
+                .map(this::toDomain)
+                .toList();
     }
 
     private Invoice toDomain(InvoiceEntity entity) {

--- a/backend/src/main/java/org/example/backend/invoiceitem/controller/InvoiceItemController.java
+++ b/backend/src/main/java/org/example/backend/invoiceitem/controller/InvoiceItemController.java
@@ -10,6 +10,7 @@ import org.springframework.web.server.ResponseStatusException;
 
 import jakarta.validation.Valid;
 
+import java.util.List;
 import java.util.UUID;
 
 @RestController
@@ -29,6 +30,29 @@ public class InvoiceItemController {
                                   @Valid @RequestBody CreateInvoiceItemRequest request) {
         try {
             return invoiceItemService.createItem(UUID.fromString(userId), UUID.fromString(customerId), UUID.fromString(invoiceId), request);
+        } catch (IllegalArgumentException e) {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, e.getMessage(), e);
+        }
+    }
+
+    @GetMapping
+    public List<InvoiceItem> getItems(@PathVariable String userId,
+                                      @PathVariable String customerId,
+                                      @PathVariable String invoiceId) {
+        try {
+            return invoiceItemService.getItems(UUID.fromString(userId), UUID.fromString(customerId), UUID.fromString(invoiceId));
+        } catch (IllegalArgumentException e) {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, e.getMessage(), e);
+        }
+    }
+
+    @GetMapping("/{itemId}")
+    public InvoiceItem getItem(@PathVariable String userId,
+                               @PathVariable String customerId,
+                               @PathVariable String invoiceId,
+                               @PathVariable String itemId) {
+        try {
+            return invoiceItemService.getItem(UUID.fromString(userId), UUID.fromString(customerId), UUID.fromString(invoiceId), UUID.fromString(itemId));
         } catch (IllegalArgumentException e) {
             throw new ResponseStatusException(HttpStatus.NOT_FOUND, e.getMessage(), e);
         }

--- a/backend/src/main/java/org/example/backend/invoiceitem/repository/InvoiceItemRepository.java
+++ b/backend/src/main/java/org/example/backend/invoiceitem/repository/InvoiceItemRepository.java
@@ -3,9 +3,11 @@ package org.example.backend.invoiceitem.repository;
 import org.example.backend.invoiceitem.entity.InvoiceItemEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
 public interface InvoiceItemRepository extends JpaRepository<InvoiceItemEntity, UUID> {
     Optional<InvoiceItemEntity> findByIdAndInvoiceId(UUID id, UUID invoiceId);
+    List<InvoiceItemEntity> findAllByInvoiceId(UUID invoiceId);
 }

--- a/backend/src/main/java/org/example/backend/invoiceitem/service/InvoiceItemService.java
+++ b/backend/src/main/java/org/example/backend/invoiceitem/service/InvoiceItemService.java
@@ -9,6 +9,7 @@ import org.example.backend.invoiceitem.repository.InvoiceItemRepository;
 import org.springframework.stereotype.Service;
 
 import java.math.BigDecimal;
+import java.util.List;
 import java.util.UUID;
 
 @Service
@@ -58,6 +59,22 @@ public class InvoiceItemService {
                 .orElseThrow(() -> new IllegalArgumentException("Item not found"));
         invoiceItemRepository.delete(entity);
         return toDomain(entity);
+    }
+
+    public InvoiceItem getItem(UUID userId, UUID customerId, UUID invoiceId, UUID itemId) {
+        invoiceRepository.findByIdAndUserIdAndCustomerId(invoiceId, userId, customerId)
+                .orElseThrow(() -> new IllegalArgumentException("Invoice not found"));
+        InvoiceItemEntity entity = invoiceItemRepository.findByIdAndInvoiceId(itemId, invoiceId)
+                .orElseThrow(() -> new IllegalArgumentException("Item not found"));
+        return toDomain(entity);
+    }
+
+    public List<InvoiceItem> getItems(UUID userId, UUID customerId, UUID invoiceId) {
+        invoiceRepository.findByIdAndUserIdAndCustomerId(invoiceId, userId, customerId)
+                .orElseThrow(() -> new IllegalArgumentException("Invoice not found"));
+        return invoiceItemRepository.findAllByInvoiceId(invoiceId).stream()
+                .map(this::toDomain)
+                .toList();
     }
 
     private InvoiceItem toDomain(InvoiceItemEntity entity) {

--- a/backend/src/main/java/org/example/backend/user/controller/UserController.java
+++ b/backend/src/main/java/org/example/backend/user/controller/UserController.java
@@ -9,6 +9,7 @@ import org.springframework.web.server.ResponseStatusException;
 
 import jakarta.validation.Valid;
 
+import java.util.List;
 import java.util.UUID;
 
 @RestController
@@ -27,6 +28,20 @@ public class UserController {
             return userService.createUser(request);
         } catch (IllegalArgumentException e) {
             throw new ResponseStatusException(HttpStatus.CONFLICT, e.getMessage(), e);
+        }
+    }
+
+    @GetMapping
+    public List<User> getUsers() {
+        return userService.getUsers();
+    }
+
+    @GetMapping("/{id}")
+    public User getUser(@PathVariable String id) {
+        try {
+            return userService.getUser(UUID.fromString(id));
+        } catch (IllegalArgumentException e) {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, e.getMessage(), e);
         }
     }
 

--- a/backend/src/main/java/org/example/backend/user/service/UserService.java
+++ b/backend/src/main/java/org/example/backend/user/service/UserService.java
@@ -6,6 +6,7 @@ import org.example.backend.user.entity.UserEntity;
 import org.example.backend.user.repository.UserRepository;
 import org.springframework.stereotype.Service;
 
+import java.util.List;
 import java.util.UUID;
 
 @Service
@@ -33,5 +34,17 @@ public class UserService {
                 .orElseThrow(() -> new IllegalArgumentException("User not found"));
         userRepository.delete(entity);
         return new User(entity.getId().toString(), entity.getEmail());
+    }
+
+    public User getUser(UUID id) {
+        UserEntity entity = userRepository.findById(id)
+                .orElseThrow(() -> new IllegalArgumentException("User not found"));
+        return new User(entity.getId().toString(), entity.getEmail());
+    }
+
+    public List<User> getUsers() {
+        return userRepository.findAll().stream()
+                .map(e -> new User(e.getId().toString(), e.getEmail()))
+                .toList();
     }
 }

--- a/backend/src/test/java/org/example/backend/customer/CustomerIntegrationTest.java
+++ b/backend/src/test/java/org/example/backend/customer/CustomerIntegrationTest.java
@@ -49,6 +49,14 @@ class CustomerIntegrationTest {
                 .andReturn().getResponse().getContentAsString();
         String customerId = objectMapper.readTree(createResponse).get("id").asText();
 
+        mockMvc.perform(get("/user/{userId}/customer", userId.toString()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].id").value(customerId));
+
+        mockMvc.perform(get("/user/{userId}/customer/{customerId}", userId.toString(), customerId))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value(customerId));
+
         UpdateCustomerRequest updateRequest = new UpdateCustomerRequest("Jane", "456", "jane@example.com", "Road");
         mockMvc.perform(put("/user/{userId}/customer/{customerId}", userId.toString(), customerId)
                         .contentType(MediaType.APPLICATION_JSON)

--- a/backend/src/test/java/org/example/backend/customer/controller/CustomerControllerTest.java
+++ b/backend/src/test/java/org/example/backend/customer/controller/CustomerControllerTest.java
@@ -12,6 +12,7 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 
+import java.util.List;
 import java.util.UUID;
 
 import static org.mockito.ArgumentMatchers.*;
@@ -69,5 +70,29 @@ class CustomerControllerTest {
         mockMvc.perform(delete("/user/{userId}/customer/{customerId}", userId.toString(), customerId.toString()))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.id").value(customerId.toString()));
+    }
+
+    @Test
+    void getCustomerReturnsCustomer() throws Exception {
+        UUID userId = UUID.randomUUID();
+        UUID customerId = UUID.randomUUID();
+        Customer response = new Customer(customerId.toString(), "Name", null, null, null);
+        given(customerService.getCustomer(userId, customerId)).willReturn(response);
+
+        mockMvc.perform(get("/user/{userId}/customer/{customerId}", userId.toString(), customerId.toString()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value(customerId.toString()));
+    }
+
+    @Test
+    void getCustomersReturnsList() throws Exception {
+        UUID userId = UUID.randomUUID();
+        Customer c1 = new Customer("1", "A", null, null, null);
+        Customer c2 = new Customer("2", "B", null, null, null);
+        given(customerService.getCustomers(userId)).willReturn(List.of(c1, c2));
+
+        mockMvc.perform(get("/user/{userId}/customer", userId.toString()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].id").value("1"));
     }
 }

--- a/backend/src/test/java/org/example/backend/customer/repository/CustomerRepositoryTest.java
+++ b/backend/src/test/java/org/example/backend/customer/repository/CustomerRepositoryTest.java
@@ -1,0 +1,47 @@
+package org.example.backend.customer.repository;
+
+import org.example.backend.customer.entity.CustomerEntity;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.util.List;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@DataJpaTest
+@ActiveProfiles("test")
+class CustomerRepositoryTest {
+    @Autowired
+    private CustomerRepository customerRepository;
+
+    @Test
+    void findAllByUserIdReturnsCustomers() {
+        UUID userId = UUID.randomUUID();
+        CustomerEntity c1 = new CustomerEntity();
+        c1.setUserId(userId);
+        c1.setName("A");
+        customerRepository.save(c1);
+
+        CustomerEntity c2 = new CustomerEntity();
+        c2.setUserId(userId);
+        c2.setName("B");
+        customerRepository.save(c2);
+
+        List<CustomerEntity> result = customerRepository.findAllByUserId(userId);
+        assertEquals(2, result.size());
+    }
+
+    @Test
+    void findByIdAndUserIdReturnsCustomer() {
+        UUID userId = UUID.randomUUID();
+        CustomerEntity c = new CustomerEntity();
+        c.setUserId(userId);
+        c.setName("A");
+        c = customerRepository.save(c);
+
+        assertTrue(customerRepository.findByIdAndUserId(c.getId(), userId).isPresent());
+    }
+}

--- a/backend/src/test/java/org/example/backend/customer/service/CustomerServiceTest.java
+++ b/backend/src/test/java/org/example/backend/customer/service/CustomerServiceTest.java
@@ -8,6 +8,7 @@ import org.example.backend.customer.repository.CustomerRepository;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -79,5 +80,38 @@ class CustomerServiceTest {
 
         verify(customerRepository).delete(entity);
         assertEquals(customerId.toString(), result.id());
+    }
+
+    @Test
+    void getCustomerReturnsDomain() {
+        UUID userId = UUID.randomUUID();
+        UUID customerId = UUID.randomUUID();
+        CustomerEntity entity = new CustomerEntity();
+        entity.setId(customerId);
+        entity.setUserId(userId);
+        entity.setName("Name");
+        when(customerRepository.findByIdAndUserId(customerId, userId)).thenReturn(Optional.of(entity));
+
+        Customer result = customerService.getCustomer(userId, customerId);
+
+        assertEquals(customerId.toString(), result.id());
+    }
+
+    @Test
+    void getCustomersReturnsAll() {
+        UUID userId = UUID.randomUUID();
+        CustomerEntity e1 = new CustomerEntity();
+        e1.setId(UUID.randomUUID());
+        e1.setUserId(userId);
+        e1.setName("A");
+        CustomerEntity e2 = new CustomerEntity();
+        e2.setId(UUID.randomUUID());
+        e2.setUserId(userId);
+        e2.setName("B");
+        when(customerRepository.findAllByUserId(userId)).thenReturn(List.of(e1, e2));
+
+        List<Customer> result = customerService.getCustomers(userId);
+
+        assertEquals(2, result.size());
     }
 }

--- a/backend/src/test/java/org/example/backend/invoice/InvoiceIntegrationTest.java
+++ b/backend/src/test/java/org/example/backend/invoice/InvoiceIntegrationTest.java
@@ -62,6 +62,14 @@ class InvoiceIntegrationTest {
                 .andReturn().getResponse().getContentAsString();
         String invoiceId = objectMapper.readTree(createResponse).get("id").asText();
 
+        mockMvc.perform(get("/user/{userId}/customer/{customerId}/invoice", userId.toString(), customerId.toString()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].id").value(invoiceId));
+
+        mockMvc.perform(get("/user/{userId}/customer/{customerId}/invoice/{invoiceId}", userId.toString(), customerId.toString(), invoiceId))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value(invoiceId));
+
         UpdateInvoiceRequest updateRequest = new UpdateInvoiceRequest("INV-2", LocalDate.now(), null, "paid", BigDecimal.ONE, BigDecimal.TEN, BigDecimal.valueOf(11), "note");
         mockMvc.perform(put("/user/{userId}/customer/{customerId}/invoice/{invoiceId}", userId.toString(), customerId.toString(), invoiceId)
                         .contentType(MediaType.APPLICATION_JSON)

--- a/backend/src/test/java/org/example/backend/invoice/controller/InvoiceControllerTest.java
+++ b/backend/src/test/java/org/example/backend/invoice/controller/InvoiceControllerTest.java
@@ -14,6 +14,7 @@ import org.springframework.test.web.servlet.MockMvc;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
+import java.util.List;
 import java.util.UUID;
 
 import static org.mockito.ArgumentMatchers.*;
@@ -74,5 +75,31 @@ class InvoiceControllerTest {
         mockMvc.perform(delete("/user/{userId}/customer/{customerId}/invoice/{invoiceId}", userId.toString(), customerId.toString(), invoiceId.toString()))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.id").value(invoiceId.toString()));
+    }
+
+    @Test
+    void getInvoiceReturnsInvoice() throws Exception {
+        UUID userId = UUID.randomUUID();
+        UUID customerId = UUID.randomUUID();
+        UUID invoiceId = UUID.randomUUID();
+        Invoice response = new Invoice(invoiceId.toString(), "INV", LocalDate.now(), null, "unpaid", BigDecimal.ONE, BigDecimal.TEN, BigDecimal.TEN, "n");
+        given(invoiceService.getInvoice(userId, customerId, invoiceId)).willReturn(response);
+
+        mockMvc.perform(get("/user/{userId}/customer/{customerId}/invoice/{invoiceId}", userId.toString(), customerId.toString(), invoiceId.toString()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value(invoiceId.toString()));
+    }
+
+    @Test
+    void getInvoicesReturnsList() throws Exception {
+        UUID userId = UUID.randomUUID();
+        UUID customerId = UUID.randomUUID();
+        Invoice i1 = new Invoice("1", "INV1", LocalDate.now(), null, "unpaid", BigDecimal.ONE, BigDecimal.TEN, BigDecimal.TEN, "n");
+        Invoice i2 = new Invoice("2", "INV2", LocalDate.now(), null, "unpaid", BigDecimal.ONE, BigDecimal.TEN, BigDecimal.TEN, "n");
+        given(invoiceService.getInvoices(userId, customerId)).willReturn(List.of(i1, i2));
+
+        mockMvc.perform(get("/user/{userId}/customer/{customerId}/invoice", userId.toString(), customerId.toString()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].id").value("1"));
     }
 }

--- a/backend/src/test/java/org/example/backend/invoice/repository/InvoiceRepositoryTest.java
+++ b/backend/src/test/java/org/example/backend/invoice/repository/InvoiceRepositoryTest.java
@@ -6,6 +6,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.test.context.ActiveProfiles;
 
+import java.time.LocalDate;
 import java.util.List;
 import java.util.UUID;
 
@@ -24,10 +25,16 @@ class InvoiceRepositoryTest {
         InvoiceEntity e1 = new InvoiceEntity();
         e1.setUserId(userId);
         e1.setCustomerId(customerId);
+        e1.setInvoiceNumber("INV-11");
+        e1.setIssueDate(LocalDate.now());
+        e1.setStatus("UNPAID");
         invoiceRepository.save(e1);
         InvoiceEntity e2 = new InvoiceEntity();
         e2.setUserId(userId);
         e2.setCustomerId(customerId);
+        e2.setInvoiceNumber("INV-12");
+        e2.setIssueDate(LocalDate.now());
+        e2.setStatus("UNPAID");
         invoiceRepository.save(e2);
 
         List<InvoiceEntity> result = invoiceRepository.findAllByUserIdAndCustomerId(userId, customerId);
@@ -41,6 +48,9 @@ class InvoiceRepositoryTest {
         InvoiceEntity e = new InvoiceEntity();
         e.setUserId(userId);
         e.setCustomerId(customerId);
+        e.setInvoiceNumber("INV-1");
+        e.setIssueDate(LocalDate.now());
+        e.setStatus("UNPAID");
         e = invoiceRepository.save(e);
 
         assertTrue(invoiceRepository.findByIdAndUserIdAndCustomerId(e.getId(), userId, customerId).isPresent());

--- a/backend/src/test/java/org/example/backend/invoice/repository/InvoiceRepositoryTest.java
+++ b/backend/src/test/java/org/example/backend/invoice/repository/InvoiceRepositoryTest.java
@@ -1,0 +1,48 @@
+package org.example.backend.invoice.repository;
+
+import org.example.backend.invoice.entity.InvoiceEntity;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.util.List;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@DataJpaTest
+@ActiveProfiles("test")
+class InvoiceRepositoryTest {
+    @Autowired
+    private InvoiceRepository invoiceRepository;
+
+    @Test
+    void findAllByUserIdAndCustomerIdReturnsInvoices() {
+        UUID userId = UUID.randomUUID();
+        UUID customerId = UUID.randomUUID();
+        InvoiceEntity e1 = new InvoiceEntity();
+        e1.setUserId(userId);
+        e1.setCustomerId(customerId);
+        invoiceRepository.save(e1);
+        InvoiceEntity e2 = new InvoiceEntity();
+        e2.setUserId(userId);
+        e2.setCustomerId(customerId);
+        invoiceRepository.save(e2);
+
+        List<InvoiceEntity> result = invoiceRepository.findAllByUserIdAndCustomerId(userId, customerId);
+        assertEquals(2, result.size());
+    }
+
+    @Test
+    void findByIdAndUserIdAndCustomerIdReturnsInvoice() {
+        UUID userId = UUID.randomUUID();
+        UUID customerId = UUID.randomUUID();
+        InvoiceEntity e = new InvoiceEntity();
+        e.setUserId(userId);
+        e.setCustomerId(customerId);
+        e = invoiceRepository.save(e);
+
+        assertTrue(invoiceRepository.findByIdAndUserIdAndCustomerId(e.getId(), userId, customerId).isPresent());
+    }
+}

--- a/backend/src/test/java/org/example/backend/invoice/service/InvoiceServiceTest.java
+++ b/backend/src/test/java/org/example/backend/invoice/service/InvoiceServiceTest.java
@@ -13,6 +13,7 @@ import org.mockito.ArgumentCaptor;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -116,5 +117,43 @@ class InvoiceServiceTest {
 
         verify(invoiceRepository).delete(entity);
         assertEquals(invoiceId.toString(), result.id());
+    }
+
+    @Test
+    void getInvoiceReturnsDomain() {
+        UUID userId = UUID.randomUUID();
+        UUID customerId = UUID.randomUUID();
+        UUID invoiceId = UUID.randomUUID();
+        InvoiceEntity entity = new InvoiceEntity();
+        entity.setId(invoiceId);
+        entity.setUserId(userId);
+        entity.setCustomerId(customerId);
+        when(invoiceRepository.findByIdAndUserIdAndCustomerId(invoiceId, userId, customerId))
+                .thenReturn(Optional.of(entity));
+
+        Invoice result = invoiceService.getInvoice(userId, customerId, invoiceId);
+
+        assertEquals(invoiceId.toString(), result.id());
+    }
+
+    @Test
+    void getInvoicesReturnsList() {
+        UUID userId = UUID.randomUUID();
+        UUID customerId = UUID.randomUUID();
+        InvoiceEntity e1 = new InvoiceEntity();
+        e1.setId(UUID.randomUUID());
+        e1.setUserId(userId);
+        e1.setCustomerId(customerId);
+        InvoiceEntity e2 = new InvoiceEntity();
+        e2.setId(UUID.randomUUID());
+        e2.setUserId(userId);
+        e2.setCustomerId(customerId);
+        when(userRepository.existsById(userId)).thenReturn(true);
+        when(customerRepository.findByIdAndUserId(customerId, userId)).thenReturn(Optional.of(new CustomerEntity()));
+        when(invoiceRepository.findAllByUserIdAndCustomerId(userId, customerId)).thenReturn(List.of(e1, e2));
+
+        List<Invoice> result = invoiceService.getInvoices(userId, customerId);
+
+        assertEquals(2, result.size());
     }
 }

--- a/backend/src/test/java/org/example/backend/invoiceitem/InvoiceItemIntegrationTest.java
+++ b/backend/src/test/java/org/example/backend/invoiceitem/InvoiceItemIntegrationTest.java
@@ -76,6 +76,14 @@ class InvoiceItemIntegrationTest {
                 .andReturn().getResponse().getContentAsString();
         String itemId = objectMapper.readTree(createResponse).get("id").asText();
 
+        mockMvc.perform(get("/user/{userId}/customer/{customerId}/invoice/{invoiceId}/item", userId.toString(), customerId.toString(), invoiceId.toString()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].id").value(itemId));
+
+        mockMvc.perform(get("/user/{userId}/customer/{customerId}/invoice/{invoiceId}/item/{itemId}", userId.toString(), customerId.toString(), invoiceId.toString(), itemId))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value(itemId));
+
         UpdateInvoiceItemRequest updateRequest = new UpdateInvoiceItemRequest("new", 3, BigDecimal.ONE);
         mockMvc.perform(put("/user/{userId}/customer/{customerId}/invoice/{invoiceId}/item/{itemId}", userId.toString(), customerId.toString(), invoiceId.toString(), itemId)
                         .contentType(MediaType.APPLICATION_JSON)

--- a/backend/src/test/java/org/example/backend/invoiceitem/controller/InvoiceItemControllerTest.java
+++ b/backend/src/test/java/org/example/backend/invoiceitem/controller/InvoiceItemControllerTest.java
@@ -13,6 +13,7 @@ import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 
 import java.math.BigDecimal;
+import java.util.List;
 import java.util.UUID;
 
 import static org.mockito.ArgumentMatchers.*;
@@ -78,5 +79,34 @@ class InvoiceItemControllerTest {
                         userId.toString(), customerId.toString(), invoiceId.toString(), itemId.toString()))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.id").value(itemId.toString()));
+    }
+
+    @Test
+    void getItemReturnsItem() throws Exception {
+        UUID userId = UUID.randomUUID();
+        UUID customerId = UUID.randomUUID();
+        UUID invoiceId = UUID.randomUUID();
+        UUID itemId = UUID.randomUUID();
+        InvoiceItem response = new InvoiceItem(itemId.toString(), "d", 1, BigDecimal.ONE, BigDecimal.ONE);
+        given(invoiceItemService.getItem(userId, customerId, invoiceId, itemId)).willReturn(response);
+
+        mockMvc.perform(get("/user/{userId}/customer/{customerId}/invoice/{invoiceId}/item/{itemId}",
+                        userId.toString(), customerId.toString(), invoiceId.toString(), itemId.toString()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value(itemId.toString()));
+    }
+
+    @Test
+    void getItemsReturnsList() throws Exception {
+        UUID userId = UUID.randomUUID();
+        UUID customerId = UUID.randomUUID();
+        UUID invoiceId = UUID.randomUUID();
+        InvoiceItem i1 = new InvoiceItem("1", "a", 1, BigDecimal.ONE, BigDecimal.ONE);
+        InvoiceItem i2 = new InvoiceItem("2", "b", 1, BigDecimal.ONE, BigDecimal.ONE);
+        given(invoiceItemService.getItems(userId, customerId, invoiceId)).willReturn(List.of(i1, i2));
+
+        mockMvc.perform(get("/user/{userId}/customer/{customerId}/invoice/{invoiceId}/item", userId.toString(), customerId.toString(), invoiceId.toString()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].id").value("1"));
     }
 }

--- a/backend/src/test/java/org/example/backend/invoiceitem/repository/InvoiceItemRepositoryTest.java
+++ b/backend/src/test/java/org/example/backend/invoiceitem/repository/InvoiceItemRepositoryTest.java
@@ -1,0 +1,57 @@
+package org.example.backend.invoiceitem.repository;
+
+import org.example.backend.invoiceitem.entity.InvoiceItemEntity;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@DataJpaTest
+@ActiveProfiles("test")
+class InvoiceItemRepositoryTest {
+    @Autowired
+    private InvoiceItemRepository invoiceItemRepository;
+
+    @Test
+    void findAllByInvoiceIdReturnsItems() {
+        UUID invoiceId = UUID.randomUUID();
+        InvoiceItemEntity e1 = new InvoiceItemEntity();
+        e1.setInvoiceId(invoiceId);
+        e1.setDescription("A");
+        e1.setQuantity(1);
+        e1.setUnitPrice(BigDecimal.ONE);
+        e1.setTotalPrice(BigDecimal.ONE);
+        invoiceItemRepository.save(e1);
+
+        InvoiceItemEntity e2 = new InvoiceItemEntity();
+        e2.setInvoiceId(invoiceId);
+        e2.setDescription("B");
+        e2.setQuantity(1);
+        e2.setUnitPrice(BigDecimal.ONE);
+        e2.setTotalPrice(BigDecimal.ONE);
+        invoiceItemRepository.save(e2);
+
+        List<InvoiceItemEntity> result = invoiceItemRepository.findAllByInvoiceId(invoiceId);
+        assertEquals(2, result.size());
+    }
+
+    @Test
+    void findByIdAndInvoiceIdReturnsItem() {
+        UUID invoiceId = UUID.randomUUID();
+        InvoiceItemEntity e = new InvoiceItemEntity();
+        e.setInvoiceId(invoiceId);
+        e.setDescription("A");
+        e.setQuantity(1);
+        e.setUnitPrice(BigDecimal.ONE);
+        e.setTotalPrice(BigDecimal.ONE);
+        e = invoiceItemRepository.save(e);
+
+        assertTrue(invoiceItemRepository.findByIdAndInvoiceId(e.getId(), invoiceId).isPresent());
+    }
+}

--- a/backend/src/test/java/org/example/backend/invoiceitem/service/InvoiceItemServiceTest.java
+++ b/backend/src/test/java/org/example/backend/invoiceitem/service/InvoiceItemServiceTest.java
@@ -11,6 +11,7 @@ import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 
 import java.math.BigDecimal;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -100,5 +101,43 @@ class InvoiceItemServiceTest {
 
         verify(invoiceItemRepository).delete(entity);
         assertEquals(itemId.toString(), result.id());
+    }
+
+    @Test
+    void getItemReturnsDomain() {
+        UUID userId = UUID.randomUUID();
+        UUID customerId = UUID.randomUUID();
+        UUID invoiceId = UUID.randomUUID();
+        UUID itemId = UUID.randomUUID();
+        when(invoiceRepository.findByIdAndUserIdAndCustomerId(invoiceId, userId, customerId))
+                .thenReturn(Optional.of(new InvoiceEntity()));
+        InvoiceItemEntity entity = new InvoiceItemEntity();
+        entity.setId(itemId);
+        entity.setInvoiceId(invoiceId);
+        when(invoiceItemRepository.findByIdAndInvoiceId(itemId, invoiceId)).thenReturn(Optional.of(entity));
+
+        InvoiceItem result = invoiceItemService.getItem(userId, customerId, invoiceId, itemId);
+
+        assertEquals(itemId.toString(), result.id());
+    }
+
+    @Test
+    void getItemsReturnsList() {
+        UUID userId = UUID.randomUUID();
+        UUID customerId = UUID.randomUUID();
+        UUID invoiceId = UUID.randomUUID();
+        when(invoiceRepository.findByIdAndUserIdAndCustomerId(invoiceId, userId, customerId))
+                .thenReturn(Optional.of(new InvoiceEntity()));
+        InvoiceItemEntity e1 = new InvoiceItemEntity();
+        e1.setId(UUID.randomUUID());
+        e1.setInvoiceId(invoiceId);
+        InvoiceItemEntity e2 = new InvoiceItemEntity();
+        e2.setId(UUID.randomUUID());
+        e2.setInvoiceId(invoiceId);
+        when(invoiceItemRepository.findAllByInvoiceId(invoiceId)).thenReturn(List.of(e1, e2));
+
+        List<InvoiceItem> result = invoiceItemService.getItems(userId, customerId, invoiceId);
+
+        assertEquals(2, result.size());
     }
 }

--- a/backend/src/test/java/org/example/backend/user/controller/UserControllerTest.java
+++ b/backend/src/test/java/org/example/backend/user/controller/UserControllerTest.java
@@ -11,6 +11,7 @@ import org.springframework.http.MediaType;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 
+import java.util.List;
 import java.util.UUID;
 
 import static org.mockito.ArgumentMatchers.any;
@@ -69,5 +70,27 @@ class UserControllerTest {
         mockMvc.perform(delete("/users/" + id))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.id").value(id.toString()));
+    }
+
+    @Test
+    void getUser() throws Exception {
+        UUID id = UUID.randomUUID();
+        User user = new User(id.toString(), "e@x.com");
+        when(userService.getUser(id)).thenReturn(user);
+
+        mockMvc.perform(get("/users/" + id))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value(id.toString()));
+    }
+
+    @Test
+    void getUsers() throws Exception {
+        User u1 = new User("1", "a@b.com");
+        User u2 = new User("2", "c@d.com");
+        when(userService.getUsers()).thenReturn(List.of(u1, u2));
+
+        mockMvc.perform(get("/users"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].id").value("1"));
     }
 }

--- a/backend/src/test/java/org/example/backend/user/repository/UserRepositoryTest.java
+++ b/backend/src/test/java/org/example/backend/user/repository/UserRepositoryTest.java
@@ -7,6 +7,7 @@ import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.test.context.ActiveProfiles;
 
 import java.util.Optional;
+import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -30,5 +31,21 @@ class UserRepositoryTest {
         userRepository.deleteById(saved.getId());
         assertFalse(userRepository.findById(saved.getId()).isPresent());
         assertFalse(userRepository.existsByEmail("test@example.com"));
+    }
+
+    @Test
+    void findAllReturnsSavedUsers() {
+        UserEntity e1 = new UserEntity();
+        e1.setEmail("a@example.com");
+        e1.setPasswordHash("pw");
+        userRepository.save(e1);
+
+        UserEntity e2 = new UserEntity();
+        e2.setEmail("b@example.com");
+        e2.setPasswordHash("pw");
+        userRepository.save(e2);
+
+        List<UserEntity> all = userRepository.findAll();
+        assertEquals(2, all.size());
     }
 }

--- a/backend/src/test/java/org/example/backend/user/service/UserServiceTest.java
+++ b/backend/src/test/java/org/example/backend/user/service/UserServiceTest.java
@@ -10,6 +10,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -62,5 +63,33 @@ class UserServiceTest {
 
         verify(userRepository).delete(entity);
         assertEquals(id.toString(), result.id());
+    }
+
+    @Test
+    void getUserReturnsDomain() {
+        UUID id = UUID.randomUUID();
+        UserEntity entity = new UserEntity();
+        entity.setId(id);
+        entity.setEmail("email@example.com");
+        when(userRepository.findById(id)).thenReturn(Optional.of(entity));
+
+        User result = userService.getUser(id);
+
+        assertEquals(id.toString(), result.id());
+    }
+
+    @Test
+    void getUsersReturnsAllUsers() {
+        UserEntity e1 = new UserEntity();
+        e1.setId(UUID.randomUUID());
+        e1.setEmail("a@example.com");
+        UserEntity e2 = new UserEntity();
+        e2.setId(UUID.randomUUID());
+        e2.setEmail("b@example.com");
+        when(userRepository.findAll()).thenReturn(List.of(e1, e2));
+
+        List<User> result = userService.getUsers();
+
+        assertEquals(2, result.size());
     }
 }


### PR DESCRIPTION
## Summary
- add GET collection and by-id endpoints for users, customers, invoices, and invoice items
- support retrieval in service and repository layers
- test controllers, services, repositories, and add integration coverage for new GET APIs

## Testing
- `./mvnw -q test` *(fails: wget failed to fetch Maven)*
- `mvn -q test` *(fails: Network is unreachable for Maven dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6892f2c8a44483209dbe1ef8d1ec9de1