### PR TITLE
docs: add backend test data guidelines

### DIFF
--- a/backend/AGENTS.md
+++ b/backend/AGENTS.md
@@ -21,6 +21,7 @@ This file defines conventions for backend code.
 
 - Each layer requires unit tests to verify its behaviour.
 - Provide a Spring Boot integration test that exercises the full request pipeline.
+- When creating tests, ensure entity or model objects set all required fields and use unique test values since data is not cleaned up.
 
 ## API Responses
 


### PR DESCRIPTION
## Summary
- instruct backend tests to set required fields on entities or models
- recommend unique test values to avoid data conflicts when tests do not clean up

## Testing
- `./mvnw test` *(fails: Failed to fetch apache-maven-3.9.11-bin.zip)*

------
https://chatgpt.com/codex/tasks/task_e_6893e7377db083209286dab7a08407cf